### PR TITLE
fix(galgame): exclude the reviewer's own declines from the publish wizard

### DIFF
--- a/apps/api/internal/galgame/service/submission_service.go
+++ b/apps/api/internal/galgame/service/submission_service.go
@@ -315,6 +315,7 @@ func (s *SubmissionService) wizardPending(
 	page, err := s.catalog.MyClaims(ctx, accessToken, catalogclient.UserClaimFilter{
 		ClaimStates: []string{catalogclient.ClaimStatePending, catalogclient.ClaimStateDeclined},
 		Limit:       wizardDefaultLimit,
+		Kind:        catalogclient.ClaimKindSubmitted,
 	})
 	if err != nil {
 		return nil, claimActionError(err)

--- a/apps/api/internal/galgame/service/wizard_search_test.go
+++ b/apps/api/internal/galgame/service/wizard_search_test.go
@@ -148,6 +148,9 @@ func TestWizard_PendingComesFromThePerUserClaimFace(t *testing.T) {
 	if got := rec.claimsQ.Get("claim_state"); got != "pending,declined" {
 		t.Errorf("claim_state = %q, want pending,declined", got)
 	}
+	if got := rec.claimsQ.Get("kind"); got != "submitted" {
+		t.Errorf("kind = %q, want submitted — the wizard must list only the caller's own claims, not their reviews", got)
+	}
 	if len(page.Pending) != 1 || page.Pending[0].WorkID != 64689 {
 		t.Fatalf("pending = %+v, want the caller's own pending claim", page.Pending)
 	}


### PR DESCRIPTION
## Bug

发布页（`/edit/galgame/publish`）搜索的「待处理」区，除了显示用户自己提交的待审核/被拒绝的投稿，还会显示用户作为审核人「拒绝」过的他人投稿。

The publish wizard's pending strip (`/edit/galgame/publish`) listed — alongside the user's own pending/declined submissions — works the user had rejected as a reviewer for other people.

## 原因 / Cause

该「待处理」区由论坛的 `wizardPending` 生成，它调用 catalog 的 `/api/v1/user/catalog/claims/mine` 时没有传 `kind`，于是拿到的是「我参与过」的全部 pending/declined claim。审核人的「拒绝」动作会以 actor 记录进 claim 事件（owner 却是别人），所以自己拒绝过的投稿也被混了进来。

The pending strip comes from the forum's `wizardPending`, which calls the catalog's `/api/v1/user/catalog/claims/mine` without a `kind`, so it receives every pending/declined claim the user has *acted on*. A reviewer's "decline" is recorded with them as the actor (while the owner is someone else), so works they rejected for others leaked in.

## 解决方式 / Solution

在 `wizardPending` 的查询里带上 `kind=submitted`（`catalogclient.ClaimKindSubmitted`），只取用户自己拥有的 claim，从而排除他们作为审核人拒绝过的他人投稿。并新增一条断言，验证 `/claims/mine` 请求必须带 `kind=submitted`。

Pass `kind=submitted` (`catalogclient.ClaimKindSubmitted`) in `wizardPending` so only the claims the user owns are returned, excluding works they rejected as a reviewer for others. Add an assertion that the claim query carries `kind=submitted`.
