### PR TITLE
feat(galgame): award trusted direct-publish from the claim feed

### DIFF
--- a/apps/api/internal/galgame/service/galgame_claim_event_sync.go
+++ b/apps/api/internal/galgame/service/galgame_claim_event_sync.go
@@ -174,6 +174,13 @@ func isApproval(ev *catalogclient.ClaimEventFeedItem) bool {
 		ev.FromState != nil && *ev.FromState == catalogclient.ClaimStatePending
 }
 
+// isDirectBirth is the trusted-submit path: the registry mints the claim
+// straight to live, so the birth event has no from_state. It is not an
+// approval (a reviewer never touched it), but it still earns the create award.
+func isDirectBirth(ev *catalogclient.ClaimEventFeedItem) bool {
+	return ev.ToState == catalogclient.ClaimStateLive && ev.FromState == nil
+}
+
 func (s *GalgameClaimEventSync) claimantOf(ctx context.Context, ev *catalogclient.ClaimEventFeedItem, gid int) int {
 	if isApproval(ev) {
 		return s.submitterOf(ctx, ev.WorkID, gid)
@@ -204,8 +211,8 @@ func (s *GalgameClaimEventSync) apply(ctx context.Context, ev *catalogclient.Cla
 			slog.Warn("claim live: 发布本地行失败, 将重试", "event", ev.ID, "gid", gid, "error", err)
 			return true
 		}
-		if isApproval(ev) {
-			return s.awardApproval(ctx, ev, gid)
+		if isApproval(ev) || isDirectBirth(ev) {
+			return s.awardLive(ctx, ev, gid)
 		}
 	case claimEffectUnpublish:
 		if err := s.galgameRepo.UnpublishLocal(int(*ev.ProductWorkID)); err != nil {
@@ -221,10 +228,10 @@ func (s *GalgameClaimEventSync) apply(ctx context.Context, ev *catalogclient.Cla
 	return false
 }
 
-func (s *GalgameClaimEventSync) awardApproval(ctx context.Context, ev *catalogclient.ClaimEventFeedItem, gid int) (retry bool) {
-	uid := s.submitterOf(ctx, ev.WorkID, gid)
+func (s *GalgameClaimEventSync) awardLive(ctx context.Context, ev *catalogclient.ClaimEventFeedItem, gid int) (retry bool) {
+	uid := s.claimantOf(ctx, ev, gid)
 	if uid <= 0 {
-		slog.Error("claim approve: 无法归属投稿人, 跳过发奖",
+		slog.Error("claim live: 无法归属投稿人, 跳过发奖",
 			"event", ev.ID, "work", ev.WorkID, "gid", gid)
 		return false
 	}
@@ -232,11 +239,11 @@ func (s *GalgameClaimEventSync) awardApproval(ctx context.Context, ev *catalogcl
 		moemoepoint.ReasonContentApproved, moemoepoint.Ref("galgame", gid),
 		moemoepoint.Key("claim_approved", strconv.FormatInt(ev.ID, 10))); err != nil {
 		if moemoepoint.IsPermanentAwardError(err) {
-			slog.Error("claim approve: 发奖被 OAuth 永久拒绝, 跳过该事件",
+			slog.Error("claim live: 发奖被 OAuth 永久拒绝, 跳过该事件",
 				"event", ev.ID, "target", uid, "error", err)
 			return false
 		}
-		slog.Warn("claim approve: 发奖瞬时失败, 将重试", "event", ev.ID, "target", uid, "error", err)
+		slog.Warn("claim live: 发奖瞬时失败, 将重试", "event", ev.ID, "target", uid, "error", err)
 		return true
 	}
 	return false

--- a/apps/api/internal/galgame/service/galgame_claim_event_sync_test.go
+++ b/apps/api/internal/galgame/service/galgame_claim_event_sync_test.go
@@ -49,19 +49,27 @@ func TestEffectOfTransition(t *testing.T) {
 	}
 }
 
-func TestOnlyApprovalAwardsFromTheFeed(t *testing.T) {
+func TestLiveAwardCondition(t *testing.T) {
 	gid := ptr(int64(11))
-	if !isApproval(event(1, ptr(catalogclient.ClaimStatePending), catalogclient.ClaimStateLive, gid)) {
+	awards := func(from *string) bool {
+		ev := event(1, from, catalogclient.ClaimStateLive, gid)
+		return isApproval(ev) || isDirectBirth(ev)
+	}
+	if !awards(ptr(catalogclient.ClaimStatePending)) {
 		t.Error("pending → live is the approval route and must award")
 	}
-	if isApproval(event(2, ptr(catalogclient.ClaimStateDraft), catalogclient.ClaimStateLive, gid)) {
+	if !awards(nil) {
+		t.Error("a trusted submit born live must award")
+	}
+	if awards(ptr(catalogclient.ClaimStateDraft)) {
 		t.Error("draft → live is the owner publishing; the request path already awarded it")
 	}
-	if isApproval(event(3, nil, catalogclient.ClaimStateLive, gid)) {
-		t.Error("a claim born live has no submission to reward")
+	if awards(ptr(catalogclient.ClaimStateHidden)) {
+		t.Error("unban must not award — lifting a ban does not make the admin an author")
 	}
-	if isApproval(event(4, ptr(catalogclient.ClaimStatePending), catalogclient.ClaimStateDeclined, gid)) {
-		t.Error("a decline is not an approval")
+	declined := event(2, ptr(catalogclient.ClaimStatePending), catalogclient.ClaimStateDeclined, gid)
+	if isApproval(declined) || isDirectBirth(declined) {
+		t.Error("a decline is not a live transition")
 	}
 }
 


### PR DESCRIPTION
## 改动 (What's implemented)

1. 新增 `isDirectBirth`：识别 trusted 提交的出生事件（`from=null, to=live`）。
2. `apply` 中发奖条件从「仅 `isApproval`」扩展为「`isApproval` 或 `isDirectBirth`」——即首次变 live 就发创建奖励。
3. `awardApproval` 改名 `awardLive`，奖励对象改为用 `claimantOf` 判定：approve 走投稿人（Redis/本地行），trusted 出生走 `actor_uid` 本人。
4. 幂等键沿用 `claim_approved:<event_id>`（保持与既有 approve 发奖同源，避免重跑重复发奖）。
5. 测试：`TestOnlyApprovalAwardsFromTheFeed` 改为 `TestLiveAwardCondition`，覆盖 pending→live、null→live 发奖，draft→live、hidden→live 不发奖。

发奖仍只在 forum 侧（`constants.RewardCreateGalgame`）定义，catalog 不感知奖励额度，额度永远单一来源。

## 预期效果 (Expected behavior)

- trusted 提交在 catalog 直接 `live` 后，forum 的 claim-event sync 识别其 `null→live` 出生事件，发放 +3 `content_approved` 奖励（与 approve 路径同源）。
- publish（`draft→live`）仍由请求路径发奖，不重复；unban（`hidden→live`）不发奖。

---

1. Add `isDirectBirth`: recognizes the trusted-submit birth event (`from=null, to=live`).
2. In `apply`, the award condition widens from `isApproval` to `isApproval || isDirectBirth` — the create award fires on the first transition to live.
3. Rename `awardApproval` to `awardLive`, and resolve the beneficiary via `claimantOf`: approvals use the submitter (Redis/local row), direct births use `actor_uid`.
4. Idempotency key stays `claim_approved:<event_id>` (same as the existing approval award, so a cursor replay never double-pays).
5. Tests: `TestOnlyApprovalAwardsFromTheFeed` becomes `TestLiveAwardCondition`, covering award on pending→live and null→live, and no award on draft→live / hidden→live.

The award amount is still defined only in forum (`constants.RewardCreateGalgame`); the catalog never knows it, so the value has a single source.

## Expected behavior

- After a trusted submit lands directly on `live`, the forum's claim-event sync sees its `null→live` birth event and issues the +3 `content_approved` award (same as the approval path).
- publish (`draft→live`) is still awarded on the request path — no double pay; unban (`hidden→live`) never awards.
