### PR TITLE
fix(user): stabilize galgame comment ordering

### DIFF
--- a/apps/api/internal/user/repository/content_repo.go
+++ b/apps/api/internal/user/repository/content_repo.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"strconv"
 	"time"
 
 	"kun-galgame-api/internal/user/dto"
@@ -66,17 +65,13 @@ type LikedPostRow struct {
 	PostID int64 `gorm:"column:post_id"`
 }
 
-func (r *UserContentRepository) FindUserLikedPostIDs(userID int, after string, limit int) ([]LikedPostRow, error) {
-	q := r.db.Table("galgame_post_like").
-		Select("id, post_id").
-		Where("user_id = ?", userID)
-	if after != "" {
-		if cursor, err := strconv.ParseInt(after, 10, 64); err == nil {
-			q = q.Where("id < ?", cursor)
-		}
-	}
+func (r *UserContentRepository) FindUserLikedPostIDs(userID int) ([]LikedPostRow, error) {
 	var rows []LikedPostRow
-	err := q.Order("id DESC").Limit(limit + 1).Scan(&rows).Error
+	err := r.db.Table("galgame_post_like").
+		Select("id, post_id").
+		Where("user_id = ?", userID).
+		Order("id DESC").
+		Scan(&rows).Error
 	return rows, err
 }
 

--- a/apps/api/internal/user/service/galgame_comment_pagination.go
+++ b/apps/api/internal/user/service/galgame_comment_pagination.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"kun-galgame-api/pkg/communityclient"
+)
+
+const communityPostBatchSize = 100
+
+type galgameCommentCursor struct {
+	Created time.Time `json:"c"`
+	ID      int64     `json:"i"`
+}
+
+type galgameCommentEntry struct {
+	ID      int64
+	Created time.Time
+	Post    *communityclient.AuthorPostView
+}
+
+func (s *UserContentService) collectAuthorGalgamePosts(ctx context.Context, userID int) ([]communityclient.AuthorPostView, error) {
+	var posts []communityclient.AuthorPostView
+	after := ""
+	seen := map[string]struct{}{}
+	for {
+		page, err := s.community.AuthorPosts(ctx, int64(userID), after, communityPostBatchSize, communityclient.AnchorSiteGame)
+		if err != nil {
+			return nil, err
+		}
+		posts = append(posts, page.Posts...)
+		if page.NextCursor == "" {
+			return posts, nil
+		}
+		if _, ok := seen[page.NextCursor]; ok {
+			return nil, fmt.Errorf("community author posts repeated cursor %q", page.NextCursor)
+		}
+		seen[page.NextCursor] = struct{}{}
+		after = page.NextCursor
+	}
+}
+
+func (s *UserContentService) resolveGalgameCommentPosts(ctx context.Context, postIDs []int64) ([]communityclient.AuthorPostView, error) {
+	posts := make([]communityclient.AuthorPostView, 0, len(postIDs))
+	for start := 0; start < len(postIDs); start += communityPostBatchSize {
+		end := min(start+communityPostBatchSize, len(postIDs))
+		page, err := s.community.ResolvePosts(ctx, postIDs[start:end])
+		if err != nil {
+			return nil, err
+		}
+		posts = append(posts, page.Posts...)
+	}
+	return posts, nil
+}
+
+func authoredGalgameCommentEntries(posts []communityclient.AuthorPostView) []galgameCommentEntry {
+	entries := make([]galgameCommentEntry, len(posts))
+	for i := range posts {
+		entries[i] = galgameCommentEntry{
+			ID:      posts[i].Post.ID,
+			Created: parseGalgameCommentTime(posts[i].Post.CreatedAt),
+			Post:    &posts[i],
+		}
+	}
+	return entries
+}
+
+func likedGalgameCommentEntries(postIDs []int64, posts []communityclient.AuthorPostView) []galgameCommentEntry {
+	byID := make(map[int64]*communityclient.AuthorPostView, len(posts))
+	for i := range posts {
+		byID[posts[i].Post.ID] = &posts[i]
+	}
+	entries := make([]galgameCommentEntry, len(postIDs))
+	for i, postID := range postIDs {
+		post := byID[postID]
+		entries[i] = galgameCommentEntry{ID: postID, Post: post}
+		if post != nil {
+			entries[i].Created = parseGalgameCommentTime(post.Post.CreatedAt)
+		}
+	}
+	return entries
+}
+
+func paginateGalgameCommentEntries(entries []galgameCommentEntry, after string, limit int) ([]galgameCommentEntry, string) {
+	if limit <= 0 {
+		return []galgameCommentEntry{}, ""
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if !entries[i].Created.Equal(entries[j].Created) {
+			return entries[i].Created.After(entries[j].Created)
+		}
+		return entries[i].ID > entries[j].ID
+	})
+
+	if cursor, ok := decodeGalgameCommentCursor(after); ok {
+		filtered := entries[:0]
+		for _, entry := range entries {
+			if entry.Created.Before(cursor.Created) ||
+				(entry.Created.Equal(cursor.Created) && entry.ID < cursor.ID) {
+				filtered = append(filtered, entry)
+			}
+		}
+		entries = filtered
+	}
+	if len(entries) <= limit {
+		return entries, ""
+	}
+	page := entries[:limit]
+	last := page[len(page)-1]
+	return page, encodeGalgameCommentCursor(last.Created, last.ID)
+}
+
+func encodeGalgameCommentCursor(created time.Time, id int64) string {
+	raw, err := json.Marshal(galgameCommentCursor{Created: created, ID: id})
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeGalgameCommentCursor(cursor string) (galgameCommentCursor, bool) {
+	if cursor == "" {
+		return galgameCommentCursor{}, false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return galgameCommentCursor{}, false
+	}
+	var payload galgameCommentCursor
+	if err := json.Unmarshal(raw, &payload); err != nil || payload.ID <= 0 {
+		return galgameCommentCursor{}, false
+	}
+	return payload, true
+}
+
+func parseGalgameCommentTime(value string) time.Time {
+	created, _ := time.Parse(time.RFC3339Nano, value)
+	return created
+}

--- a/apps/api/internal/user/service/galgame_comment_pagination_test.go
+++ b/apps/api/internal/user/service/galgame_comment_pagination_test.go
@@ -1,0 +1,190 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"kun-galgame-api/pkg/communityclient"
+)
+
+func TestPaginateGalgameCommentEntriesUsesCreatedAtAndID(t *testing.T) {
+	posts := []communityclient.AuthorPostView{
+		authorPost(400, "2026-08-20T08:00:00Z"),
+		authorPost(200, "2026-08-20T10:00:00Z"),
+		authorPost(300, "2026-08-20T10:00:00Z"),
+		authorPost(100, "2026-08-20T09:00:00Z"),
+	}
+
+	first, cursor := paginateGalgameCommentEntries(authoredGalgameCommentEntries(posts), "", 2)
+	if got, want := entryIDs(first), []int64{300, 200}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("first page ids = %v, want %v", got, want)
+	}
+	if cursor == "" {
+		t.Fatal("first page must return a composite cursor")
+	}
+	decoded, ok := decodeGalgameCommentCursor(cursor)
+	if !ok || decoded.ID != 200 || decoded.Created != parseGalgameCommentTime("2026-08-20T10:00:00Z") {
+		t.Fatalf("decoded cursor = %+v, ok=%v", decoded, ok)
+	}
+
+	second, next := paginateGalgameCommentEntries(authoredGalgameCommentEntries(posts), cursor, 2)
+	if got, want := entryIDs(second), []int64{100, 400}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("second page ids = %v, want %v", got, want)
+	}
+	if next != "" {
+		t.Fatalf("last page cursor = %q, want empty", next)
+	}
+}
+
+func TestPaginateGalgameCommentEntriesSplitsEqualTimestampsByID(t *testing.T) {
+	const created = "2026-08-20T10:00:00Z"
+	posts := []communityclient.AuthorPostView{
+		authorPost(10, created),
+		authorPost(30, created),
+		authorPost(20, created),
+	}
+
+	first, cursor := paginateGalgameCommentEntries(authoredGalgameCommentEntries(posts), "", 2)
+	if got, want := entryIDs(first), []int64{30, 20}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("first page ids = %v, want %v", got, want)
+	}
+
+	second, next := paginateGalgameCommentEntries(authoredGalgameCommentEntries(posts), cursor, 2)
+	if got, want := entryIDs(second), []int64{10}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("second page ids = %v, want %v", got, want)
+	}
+	if next != "" {
+		t.Fatalf("last page cursor = %q, want empty", next)
+	}
+}
+
+func TestLikedGalgameCommentEntriesKeepMissingPostsStable(t *testing.T) {
+	postIDs := []int64{20, 900, 30}
+	posts := []communityclient.AuthorPostView{
+		authorPost(20, "2026-08-20T09:00:00Z"),
+		authorPost(30, "2026-08-20T10:00:00Z"),
+	}
+
+	first, cursor := paginateGalgameCommentEntries(likedGalgameCommentEntries(postIDs, posts), "", 2)
+	if got, want := entryIDs(first), []int64{30, 20}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("first liked page ids = %v, want %v", got, want)
+	}
+	if cursor == "" {
+		t.Fatal("first liked page must return a composite cursor")
+	}
+
+	second, next := paginateGalgameCommentEntries(likedGalgameCommentEntries(postIDs, posts), cursor, 2)
+	if got, want := entryIDs(second), []int64{900}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("second liked page ids = %v, want %v", got, want)
+	}
+	if second[0].Post != nil {
+		t.Fatal("an unresolved liked post must remain a deleted placeholder")
+	}
+	if next != "" {
+		t.Fatalf("last page cursor = %q, want empty", next)
+	}
+}
+
+func TestCollectAuthorGalgamePostsExhaustsUpstreamBeforeSorting(t *testing.T) {
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("limit") != strconv.Itoa(communityPostBatchSize) ||
+			r.URL.Query().Get("anchor_kind") != strconv.Itoa(communityclient.AnchorSiteGame) {
+			t.Errorf("unexpected query: %s", r.URL.RawQuery)
+		}
+		after := r.URL.Query().Get("after")
+		requests = append(requests, after)
+		posts := []communityclient.AuthorPostView{
+			authorPost(300, "2026-08-20T08:00:00Z"),
+			authorPost(200, "2026-08-20T10:00:00Z"),
+		}
+		next := "200"
+		if after == "200" {
+			posts = []communityclient.AuthorPostView{authorPost(100, "2026-08-20T09:00:00Z")}
+			next = ""
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code": 0,
+			"data": map[string]any{"posts": posts, "next_cursor": next},
+		})
+	}))
+	defer srv.Close()
+
+	s := &UserContentService{community: communityclient.New(communityclient.Config{
+		BaseURL: srv.URL, ClientID: "test", ClientSecret: "test",
+	})}
+	posts, err := s.collectAuthorGalgamePosts(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("collectAuthorGalgamePosts: %v", err)
+	}
+	page, _ := paginateGalgameCommentEntries(authoredGalgameCommentEntries(posts), "", 3)
+	if got, want := entryIDs(page), []int64{200, 100, 300}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("globally sorted ids = %v, want %v", got, want)
+	}
+	if got, want := requests, []string{"", "200"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("upstream cursors = %v, want %v", got, want)
+	}
+}
+
+func TestResolveGalgameCommentPostsUsesContractBatchSize(t *testing.T) {
+	var batchSizes []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req communityclient.PostsResolveRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		batchSizes = append(batchSizes, len(req.IDs))
+		posts := make([]communityclient.AuthorPostView, len(req.IDs))
+		for i, id := range req.IDs {
+			posts[i] = authorPost(id, "2026-08-20T10:00:00Z")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code": 0,
+			"data": map[string]any{"posts": posts},
+		})
+	}))
+	defer srv.Close()
+
+	s := &UserContentService{community: communityclient.New(communityclient.Config{
+		BaseURL: srv.URL, ClientID: "test", ClientSecret: "test",
+	})}
+	ids := make([]int64, 201)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+	posts, err := s.resolveGalgameCommentPosts(context.Background(), ids)
+	if err != nil {
+		t.Fatalf("resolveGalgameCommentPosts: %v", err)
+	}
+	if len(posts) != len(ids) {
+		t.Fatalf("resolved posts = %d, want %d", len(posts), len(ids))
+	}
+	if got, want := batchSizes, []int{100, 100, 1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("batch sizes = %v, want %v", got, want)
+	}
+}
+
+func authorPost(id int64, created string) communityclient.AuthorPostView {
+	return communityclient.AuthorPostView{
+		Post: communityclient.PostView{ID: id, CreatedAt: created},
+		Thread: communityclient.PostThreadContext{
+			AnchorKind: communityclient.AnchorSiteGame,
+			AnchorID:   "1",
+		},
+	}
+}
+
+func entryIDs(entries []galgameCommentEntry) []int64 {
+	ids := make([]int64, len(entries))
+	for i, entry := range entries {
+		ids[i] = entry.ID
+	}
+	return ids
+}

--- a/apps/api/internal/user/service/user_content_service.go
+++ b/apps/api/internal/user/service/user_content_service.go
@@ -222,16 +222,18 @@ func (s *UserContentService) GetUserGalgameComments(
 }
 
 func (s *UserContentService) authoredGalgameComments(ctx context.Context, userID int, after string, limit int) ([]dto.UserGalgameComment, string, *errors.AppError) {
-	resp, err := s.community.AuthorPosts(ctx, int64(userID), after, limit, communityclient.AnchorSiteGame)
+	posts, err := s.collectAuthorGalgamePosts(ctx, userID)
 	if err != nil {
 		if communityDown(err) {
 			return []dto.UserGalgameComment{}, "", nil
 		}
 		return nil, "", errors.ErrInternal("获取用户 Galgame 评论列表失败")
 	}
+	page, nextCursor := paginateGalgameCommentEntries(authoredGalgameCommentEntries(posts), after, limit)
 	owner := s.userClient.Hydrate(ctx, []int{userID})[userID]
-	items := make([]dto.UserGalgameComment, 0, len(resp.Posts))
-	for _, av := range resp.Posts {
+	items := make([]dto.UserGalgameComment, 0, len(page))
+	for _, entry := range page {
+		av := entry.Post
 		items = append(items, dto.UserGalgameComment{
 			ID:          av.Post.ID,
 			GalgameID:   anchorGalgameID(av.Thread),
@@ -242,48 +244,49 @@ func (s *UserContentService) authoredGalgameComments(ctx context.Context, userID
 			Deleted:     false,
 		})
 	}
-	return items, resp.NextCursor, nil
+	return items, nextCursor, nil
 }
 
 func (s *UserContentService) likedGalgameComments(ctx context.Context, userID int, after string, limit int) ([]dto.UserGalgameComment, string, *errors.AppError) {
-	rows, err := s.userContentRepo.FindUserLikedPostIDs(userID, after, limit)
+	rows, err := s.userContentRepo.FindUserLikedPostIDs(userID)
 	if err != nil {
 		return nil, "", errors.ErrInternal("获取用户 Galgame 评论列表失败")
-	}
-	nextCursor := ""
-	if len(rows) > limit {
-		nextCursor = strconv.FormatInt(rows[limit-1].ID, 10)
-		rows = rows[:limit]
 	}
 	if len(rows) == 0 {
 		return []dto.UserGalgameComment{}, "", nil
 	}
 
 	postIDs := make([]int64, len(rows))
-	for i, r := range rows {
-		postIDs[i] = r.PostID
+	for i, row := range rows {
+		postIDs[i] = row.PostID
 	}
-	resolved, err := s.community.ResolvePosts(ctx, postIDs)
+	posts, err := s.resolveGalgameCommentPosts(ctx, postIDs)
 	if err != nil {
 		if communityDown(err) {
 			return []dto.UserGalgameComment{}, "", nil
 		}
 		return nil, "", errors.ErrInternal("获取用户 Galgame 评论列表失败")
 	}
-	byID := make(map[int64]communityclient.AuthorPostView, len(resolved.Posts))
-	authorIDs := make([]int, 0, len(resolved.Posts))
-	for _, av := range resolved.Posts {
-		byID[av.Post.ID] = av
-		authorIDs = append(authorIDs, int(av.Post.AuthorID))
+
+	page, nextCursor := paginateGalgameCommentEntries(likedGalgameCommentEntries(postIDs, posts), after, limit)
+	authorIDs := make([]int, 0, len(page))
+	for _, entry := range page {
+		if entry.Post != nil {
+			authorIDs = append(authorIDs, int(entry.Post.Post.AuthorID))
+		}
 	}
 	userMap := s.userClient.Hydrate(ctx, authorIDs)
 
-	items := make([]dto.UserGalgameComment, 0, len(rows))
-	for _, r := range rows {
-		av, ok := byID[r.PostID]
+	items := make([]dto.UserGalgameComment, 0, len(page))
+	for _, entry := range page {
+		if entry.Post == nil {
+			items = append(items, dto.UserGalgameComment{ID: entry.ID, Deleted: true, User: dto.UserBrief{}})
+			continue
+		}
+		av := entry.Post
 		author := userMap[int(av.Post.AuthorID)]
-		if !ok || !userclient.IsRenderable(author) {
-			items = append(items, dto.UserGalgameComment{ID: r.PostID, Deleted: true, User: dto.UserBrief{}})
+		if !userclient.IsRenderable(author) {
+			items = append(items, dto.UserGalgameComment{ID: entry.ID, Deleted: true, User: dto.UserBrief{}})
 			continue
 		}
 		items = append(items, dto.UserGalgameComment{


### PR DESCRIPTION
## Summary

- order authored and liked Galgame comments by `created_at DESC, id DESC`
- paginate both profile tabs with an opaque `created_at + id` composite cursor
- preserve deleted placeholders for liked comments
- batch community reads at the contract limit of 100

## Root cause

The authored-comments tab forwarded the community author's post-ID cursor, so migrated posts were effectively ordered by post ID instead of their historical creation time. The liked-comments tab was ordered by the local like-row ID, which represented like insertion order instead of the liked comment's creation time.

Sorting only the currently returned frontend page would not fix ordering across page boundaries.

## Changes

The API now collects the complete relevant comment set, resolves liked posts in batches, sorts by comment creation time with post ID as the deterministic tie-breaker, and applies an opaque composite cursor before returning each page.

## Tests

- `go build ./...`
- `go vet ./...`
- `GOPROXY=https://goproxy.cn,direct go run github.com/kisielk/errcheck@v1.9.0 -exclude .errcheck-exclude ./...`
- `go test -race ./internal/user/service`
- `go test ./internal/user/service ./internal/user/repository`
- all Go packages except `internal/app` (whose route golden file is converted to CRLF by this Windows checkout) pass

## Deployment

No database migration is required.