### PR TITLE
fix(galgame): stamp the creator when claiming a draft

### DIFF
--- a/apps/api/internal/galgame/service/submission_service.go
+++ b/apps/api/internal/galgame/service/submission_service.go
@@ -105,6 +105,19 @@ func (s *SubmissionService) Claim(
 	if appErr != nil {
 		return nil, appErr
 	}
+	// Stamp the local row now instead of waiting for the claim-event cron,
+	// exactly as Submit and ClaimUnclaimed do: the caller is redirected to
+	// /galgame/:gid the moment this returns, and until the row (and its
+	// creator_user_id) exists the detail page renders no 贡献者 card.
+	if err := s.galgameRepo.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := s.galgameRepo.PublishLocal(tx, gid); err != nil {
+			return err
+		}
+		return s.galgameRepo.SetCreatorIfUnset(tx, gid, int(uid))
+	}); err != nil {
+		slog.Warn("claim: 建立本地 galgame 行失败, 等待 claim 事件同步补齐",
+			"gid", gid, "uid", uid, "error", err)
+	}
 	if err := s.galgameRepo.Touch(s.galgameRepo.DB().WithContext(ctx), gid); err != nil {
 		slog.Warn("claim: 刷新本地 galgame resource_update_time 失败", "gid", gid, "error", err)
 	}


### PR DESCRIPTION
## Bug / 问题

在「发布 Galgame」向导中，对非 VNDB（或机器导入）的「草稿」作品点击「认领并发布」后，跳转到的 Galgame 详情页无法显示「贡献者 / 创造者」的头像信息——贡献者卡片整体不渲染。

In the "发布 Galgame" wizard, after claiming and publishing a non-VNDB (or machine-imported) work that is in "draft" state, the resulting Galgame detail page fails to render the contributor/creator card (the creator's avatar and the contributors are both missing).

## Cause / 出现原因

详情页的「创造者」来自论坛本地 `galgame.creator_user_id`（`GalgameService.ownerOf()`）。三个发布入口里，`Submit`（新建申请）和 `ClaimUnclaimed`（收录未认领作品）都会同步写入该字段；但 `Claim`（认领并发布「草稿」）在上游发布成功后只调用了 `Touch` 刷新 `resource_update_time`，没有同步写入 `creator_user_id`，而是依赖异步的 claim 事件 cron 去补齐。在 cron 运行前，`ownerOf()` 返回 0，前端 `hasCreator = user.id > 0` 为 false，贡献者卡片不渲染。

The detail page's creator comes from the local `galgame.creator_user_id` (`GalgameService.ownerOf()`). Of the three publish entry points, `Submit` (new submission) and `ClaimUnclaimed` (adopting an unclaimed work) both write that field synchronously; but `Claim` (claiming and publishing a "draft") only called `Touch` to refresh `resource_update_time` after the upstream publish, leaving `creator_user_id` to the async claim-event cron. Until that cron ran, `ownerOf()` returned 0, so the frontend's `hasCreator = user.id > 0` was false and the contributor card was not rendered.

## Fix / 解决方式

在 `SubmissionService.Claim` 发布成功后，同步执行 `PublishLocal` + `SetCreatorIfUnset`（与 `Submit` / `ClaimUnclaimed` 保持一致），立即写入本地行与 `creator_user_id`，使认领发布后跳转到的详情页立刻拥有创造者。无 schema 变更，无需迁移。

After `SubmissionService.Claim` publishes successfully, synchronously run `PublishLocal` + `SetCreatorIfUnset` (mirroring `Submit` / `ClaimUnclaimed`) to stamp the local row and `creator_user_id` immediately, so the detail page the caller is redirected to already has a creator. No schema change; no migration required.
