### PR TITLE
feat(galgame): delete drafts and fix the publish banner upload

### DIFF
--- a/apps/api/internal/app/router.go
+++ b/apps/api/internal/app/router.go
@@ -276,6 +276,7 @@ func (a *App) setupRoutes() {
 	authed.Post("/galgame/:gid/claim", a.GalgameSubmissionHandler.Claim)
 	authed.Post("/galgame/:gid/resubmit", a.GalgameSubmissionHandler.Resubmit)
 	authed.Delete("/galgame/:gid", a.GalgameSubmissionHandler.Withdraw)
+	authed.Delete("/galgame/:gid/draft", a.GalgameSubmissionHandler.DeleteDraft)
 
 	authed.Get("/galgame/interactions/mine", a.GalgameHandler.MyInteractions)
 	authed.Get("/galgame/playtime/mine", a.GalgamePlaytimeHandler.ListMine)

--- a/apps/api/internal/app/testdata/routes.golden
+++ b/apps/api/internal/app/testdata/routes.golden
@@ -10,6 +10,7 @@ DELETE /api/galgame-rating/:id/comments/:postId       cors.New → middleware.Na
 DELETE /api/galgame-resource/:id/comments/:postId     cors.New → middleware.NamePreference → OptionalAuth → Auth → ResourceCommentHandler.ResourceDelete
 DELETE /api/galgame/:gid                              cors.New → middleware.NamePreference → OptionalAuth → Auth → SubmissionHandler.Withdraw
 DELETE /api/galgame/:gid/cover/:coverId/vote          cors.New → middleware.NamePreference → OptionalAuth → Auth → CoverVoteHandler.Unvote
+DELETE /api/galgame/:gid/draft                        cors.New → middleware.NamePreference → OptionalAuth → Auth → SubmissionHandler.DeleteDraft
 DELETE /api/galgame/:gid/resource                     cors.New → middleware.NamePreference → OptionalAuth → Auth → ResourceHandler.DeleteResource
 DELETE /api/galgame/collection/:cid                   cors.New → middleware.NamePreference → OptionalAuth → Auth → GalgameCollectionHandler.Delete
 DELETE /api/galgame/comments/:postId                  cors.New → middleware.NamePreference → OptionalAuth → Auth → CommunityCommentHandler.Delete

--- a/apps/api/internal/galgame/handler/submission_handler.go
+++ b/apps/api/internal/galgame/handler/submission_handler.go
@@ -118,6 +118,21 @@ func (h *SubmissionHandler) Withdraw(c fiber.Ctx) error {
 	return response.OKMessage(c, "撤回成功")
 }
 
+func (h *SubmissionHandler) DeleteDraft(c fiber.Ctx) error {
+	token, appErr := userToken(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	gid, appErr := submissionGID(c)
+	if appErr != nil {
+		return response.Error(c, appErr)
+	}
+	if appErr := h.svc.DeleteDraft(c.Context(), token, gid); appErr != nil {
+		return response.Error(c, appErr)
+	}
+	return response.OKMessage(c, "删除成功")
+}
+
 func (h *SubmissionHandler) ListMine(c fiber.Ctx) error {
 	token, appErr := userToken(c)
 	if appErr != nil {

--- a/apps/api/internal/galgame/repository/galgame_repo.go
+++ b/apps/api/internal/galgame/repository/galgame_repo.go
@@ -97,6 +97,10 @@ func (r *GalgameRepository) UnpublishLocal(galgameID int) error {
 		UpdateColumn("published", false).Error
 }
 
+func (r *GalgameRepository) DeleteLocal(galgameID int) error {
+	return r.db.Where("id = ?", galgameID).Delete(&model.GalgameLocal{}).Error
+}
+
 func (r *GalgameRepository) EnsureLocalStub(tx *gorm.DB, galgameID int) error {
 	return tx.Clauses(clause.OnConflict{DoNothing: true}).
 		Create(&model.GalgameLocal{ID: galgameID}).Error

--- a/apps/api/internal/galgame/service/submission_service.go
+++ b/apps/api/internal/galgame/service/submission_service.go
@@ -81,13 +81,24 @@ func (s *SubmissionService) Submit(
 	patch := form.CoverPatch()
 	attached := patch == nil
 	if patch != nil {
-		if _, err := s.catalog.CreateEditProposalUser(ctx, accessToken, catalogclient.UserEditCreateRequest{
+		created, err := s.catalog.CreateEditProposalUser(ctx, accessToken, catalogclient.UserEditCreateRequest{
 			EntityType: catalogclient.EntityTypeWork, EntityID: res.WorkID,
 			Patch: patch, Note: "投稿时提交的横幅图",
-		}); err != nil {
+		})
+		switch {
+		case err != nil:
 			slog.Error("submit: 附加横幅图失败, 投稿已建立但封面丢失", "work", res.WorkID, "error", err)
-		} else {
+		case created.Merged:
 			attached = true
+		default:
+			// Approving the claim moves only the claim state, never the open
+			// edit proposals, so a banner that stays open here is never shown.
+			// The submitter owns the work, so merge it now instead.
+			if _, err := s.catalog.MergeEditProposalUser(ctx, accessToken, created.Proposal.ID, ""); err != nil {
+				slog.Error("submit: 合并横幅图提案失败", "proposal", created.Proposal.ID, "error", err)
+			} else {
+				attached = true
+			}
 		}
 	}
 	return &SubmitResult{

--- a/apps/api/internal/galgame/service/submission_service.go
+++ b/apps/api/internal/galgame/service/submission_service.go
@@ -229,6 +229,24 @@ func (s *SubmissionService) Withdraw(
 	return s.act(ctx, accessToken, gid, catalogclient.ClaimActionWithdraw, "")
 }
 
+func (s *SubmissionService) DeleteDraft(
+	ctx context.Context,
+	accessToken string,
+	gid int,
+) *errors.AppError {
+	workID, appErr := s.workIDOf(ctx, gid)
+	if appErr != nil {
+		return appErr
+	}
+	if err := s.catalog.DeleteDraftUser(ctx, accessToken, workID); err != nil {
+		return claimActionError(err)
+	}
+	if err := s.galgameRepo.DeleteLocal(gid); err != nil {
+		slog.Warn("delete draft: 删除本地 galgame 行失败", "gid", gid, "error", err)
+	}
+	return nil
+}
+
 func (s *SubmissionService) act(
 	ctx context.Context,
 	accessToken string,

--- a/apps/api/internal/galgame/service/submission_submit_test.go
+++ b/apps/api/internal/galgame/service/submission_submit_test.go
@@ -21,6 +21,8 @@ type submitRecorder struct {
 	editBody   map[string]any
 	editPath   string
 	editAuth   string
+	mergePath  string
+	mergeAuth  string
 }
 
 func (r *submitRecorder) service(t *testing.T) *SubmissionService {
@@ -36,10 +38,13 @@ func (r *submitRecorder) service(t *testing.T) *SubmissionService {
 			r.body = body
 			r.submitPath = req.URL.Path
 			r.submitAuth = req.Header.Get("Authorization")
-		case strings.Contains(req.URL.Path, "/catalog/edit/proposals"):
+		case strings.HasSuffix(req.URL.Path, "/catalog/edit/proposals"):
 			r.editBody = body
 			r.editPath = req.URL.Path
 			r.editAuth = req.Header.Get("Authorization")
+		case strings.HasSuffix(req.URL.Path, "/merge"):
+			r.mergePath = req.URL.Path
+			r.mergeAuth = req.Header.Get("Authorization")
 		}
 		r.mu.Unlock()
 
@@ -66,6 +71,8 @@ func (r *submitRecorder) service(t *testing.T) *SubmissionService {
 			_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":{"items":[` +
 				`{"id":90210,"claimed_by":{"site":"kungal","work_id":90210,"state":"pending"}}` +
 				`],"next_cursor":null}}`))
+		case strings.HasSuffix(req.URL.Path, "/merge"):
+			_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":{"id":9,"seq":2,"action":"merged"}}`))
 		default:
 			_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":{"merged":false,"proposal":{"id":1}}}`))
 		}
@@ -144,6 +151,12 @@ func TestSubmitAttachesTheBannerAsAFollowUpEdit(t *testing.T) {
 	}
 	if _, ok := rec.editBody["site"]; ok {
 		t.Errorf("the banner edit must assert no site: %v", rec.editBody)
+	}
+	if rec.mergePath != "/api/v1/user/catalog/edit/proposals/1/merge" {
+		t.Errorf("open banner proposal hit %q, want the merge face", rec.mergePath)
+	}
+	if rec.mergeAuth != "Bearer user-jwt" {
+		t.Errorf("banner merge auth = %q, want the submitter's bearer", rec.mergeAuth)
 	}
 }
 

--- a/apps/api/pkg/catalogclient/user_claims.go
+++ b/apps/api/pkg/catalogclient/user_claims.go
@@ -30,6 +30,12 @@ func (c *Client) ActOnClaimUser(ctx context.Context, accessToken string, workID 
 		userClaimBase+"/works/"+strconv.FormatInt(workID, 10)+"/claim-actions/"+action, req)
 }
 
+func (c *Client) DeleteDraftUser(ctx context.Context, accessToken string, workID int64) error {
+	_, err := userEditDo[struct{}](ctx, c, http.MethodDelete, accessToken,
+		userClaimBase+"/works/"+strconv.FormatInt(workID, 10), nil)
+	return err
+}
+
 func (c *Client) MyClaims(ctx context.Context, accessToken string, f UserClaimFilter) (*UserClaimPage, error) {
 	q := url.Values{}
 	if len(f.ClaimStates) > 0 {

--- a/apps/web/app/components/edit/galgame/Footer.vue
+++ b/apps/web/app/components/edit/galgame/Footer.vue
@@ -58,12 +58,8 @@ const handleSubmitGalgame = async () => {
 
   const { banner: _bannerBlob, ...jsonFields } = data
   let bannerHash = ''
-  if (banner instanceof File) {
-    const uploaded = await uploadGalgameImage(
-      banner,
-      'galgame_banner',
-      banner.name
-    )
+  if (banner) {
+    const uploaded = await uploadGalgameImage(banner, 'galgame_banner')
     if (uploaded) {
       bannerHash = uploaded.hash
     }

--- a/apps/web/app/components/edit/galgame/Mine.vue
+++ b/apps/web/app/components/edit/galgame/Mine.vue
@@ -51,6 +51,28 @@ const handleResubmit = async (item: UserClaimItem) => {
     refresh()
   }
 }
+
+const isDeleting = ref<Record<number, boolean>>({})
+
+const handleDelete = async (item: UserClaimItem) => {
+  const ok = await useComponentMessageStore().alert(
+    '确定删除这条草稿吗?',
+    '删除后该草稿会被彻底移除, 且无法恢复。'
+  )
+  if (!ok) {
+    return
+  }
+  const gid = galgameClaimGid(item)
+  isDeleting.value = { ...isDeleting.value, [gid]: true }
+  const res = await kunFetch<string>(`/galgame/${gid}/draft`, {
+    method: 'DELETE'
+  })
+  isDeleting.value = { ...isDeleting.value, [gid]: false }
+  if (res !== null) {
+    useMessage('已删除', 'success')
+    refresh()
+  }
+}
 </script>
 
 <template>
@@ -129,6 +151,17 @@ const handleResubmit = async (item: UserClaimItem) => {
               @click="handleWithdraw(item)"
             >
               撤回
+            </KunButton>
+            <KunButton
+              v-if="item.claim_state === CLAIM_STATE_DRAFT"
+              size="sm"
+              color="danger"
+              variant="flat"
+              :loading="isDeleting[galgameClaimGid(item)]"
+              :disabled="isDeleting[galgameClaimGid(item)]"
+              @click="handleDelete(item)"
+            >
+              删除
             </KunButton>
           </template>
         </template>


### PR DESCRIPTION
## Bug / 问题（预览图修复）

发布非 VNDB 未收录 Galgame 时，提交的预览图在审核后不显示，需要二次修改上传才生效。

When publishing a non-VNDB galgame, the submitted preview image never appears after review — it only takes effect after a second edit and re-upload.

### 出现原因 / Cause

前端 `Footer.vue` 用 `banner instanceof File` 判断是否上传横幅，但 `KunUpload` 的 `set-image` 事件发出的、以及 `getImage()` 从 localforage 取回的都是 **Blob**（不是 File），所以该判断恒为 false → 横幅从未上传 → `banner_hash` 为空 → 后端 `CoverPatch()` 返回 nil，横幅编辑提案根本没创建。

`Footer.vue` gated the upload on `banner instanceof File`, but both KunUpload's `set-image` event and `getImage()` return a **Blob**, not a File — so the check was always false, the banner was never uploaded, `banner_hash` was empty, and the backend's `CoverPatch()` returned nil (the banner edit proposal was never filed).

### 解决方式 / Fix

1. 把 `banner instanceof File` 改成 `if (banner)`（Blob 也能上传）。
2. `Submit` 在横幅提案未自动合并时显式合并（投稿人即 owner），确保横幅真正落地。

1. Change `banner instanceof File` to `if (banner)`.
2. `Submit` merges the banner edit proposal explicitly when it is not auto-merged (the submitter is the owner), so the banner always lands.

## 功能 / Feature（草稿删除）

在「我的提交」草稿条目最右侧新增红色「删除」按钮，走 `DELETE /galgame/:gid/draft`：先调用 catalog 的软删端点，再清理本地 galgame 行（仅限 owner、仅限 draft 状态）。

Adds a red 删除 button on the far right of draft entries in 我的提交, backed by `DELETE /galgame/:gid/draft`, which soft-deletes the catalog work and removes the local galgame row (owner-only, draft-only).

> 草稿删除依赖 infra 侧的 `DELETE /api/v1/user/catalog/works/{id}`（见 kun-galgame-infra 的对应 PR）。Draft deletion depends on the catalog endpoint `DELETE /api/v1/user/catalog/works/{id}` from the corresponding kun-galgame-infra PR.
