### PR TITLE
fix(web): refresh KunTime when its props change

### DIFF
--- a/apps/web/app/components/KunTime.vue
+++ b/apps/web/app/components/KunTime.vue
@@ -29,7 +29,14 @@ const render = (): string => {
   })
 }
 
-const text = useState(`kun-time-${useId()}`, render)
+const text = ref(render())
+
+watch(
+  () => [props.time, props.type, props.showYear],
+  () => {
+    text.value = render()
+  }
+)
 
 let timer: ReturnType<typeof setInterval> | undefined
 onMounted(() => {


### PR DESCRIPTION
### 背景 / Background

论坛通知中心的旧评论通知，时间被显示成错误的缓存时间（看起来像是"当前访问时的现在时间"），而不是每条消息自己的创建时间。

In the forum message center, old comment notifications displayed a stale cached timestamp (perceived as "the current visit time") instead of each message's own creation time.

### Bug / 问题

`/message/notice`（通知）、`/message/muted`（静音）、私聊页的列表都用 `:key="index"` 渲染 `KunTime`。翻页时同一位置的组件被**复用**而非重新挂载。`KunTime` 的时间文本存放在 `useState('kun-time-' + useId(), render)` —— 这是 Nuxt 全局持久 state，key 依赖组件位置且**不是响应式的**；它只在首次初始化、`onMounted`、以及 60 秒定时器（仅 `relative`/`auto` 类型）里重算。`datetime` 类型既没有定时器，翻页又不会重新触发 `onMounted`，于是从第 2 页开始，所有旧评论都继续显示第 1 页对应索引位置的时间。

`/message/notice`, `/message/muted` and the private-message pages render `KunTime` inside a `v-for` keyed by `:key="index"`. Turning a page **reuses** the component instance at each position instead of remounting it. `KunTime`'s text lived in `useState('kun-time-' + useId(), render)` — a Nuxt-global persistent state keyed by component position and **not reactive**; it only recomputed on first init, in `onMounted`, and on the 60-second timer (`relative`/`auto` types only). The `datetime` type has no timer, and pagination never re-fires `onMounted`, so from page 2 onward every old comment kept showing the page-1 timestamp at the same index position.

### 复现 / Reproduction

1. 登录后进入 `/message/notice`（需多于 30 条消息才有分页）
2. 点击第 2 页
3. 观察到第 2 页的时间与第 1 页完全相同 —— 例如 `/topic/3867?reply=74` 本应显示 `2026-07-30 13:49`，却显示第 1 页的 `2026-08-05 21:01`

1. Log in and open `/message/notice` (needs more than 30 messages so pagination appears)
2. Click page 2
3. The displayed times are identical to page 1 — e.g. `/topic/3867?reply=74` should read `2026-07-30 13:49` but shows page 1's `2026-08-05 21:01`

### 解决方式 / Fix

`apps/web/app/components/KunTime.vue`：用本地 `ref(render())` + 对 `props.time / type / showYear` 的 `watch` 替代全局 `useState`。组件被复用且 props 变化时立即重算，翻页后时间即正确；`relative` 类型的 60 秒定时器保持不变。一次修复覆盖通知、静音、私聊三个列表页。

In `apps/web/app/components/KunTime.vue`, replace the global `useState` with a local `ref(render())` plus a `watch` over `props.time / type / showYear`. A reused instance now recomputes immediately when the props change, so pagination shows the correct time; the 60-second `relative` timer is unchanged. This single fix covers the notice, muted and private-message list pages.

### 验证 / Verification

- 无头浏览器实测：修复前第 2 页时间与第 1 页完全重复；修复后第 2 页各消息显示的时间与其数据库 `created` 值逐条一致。
- `eslint` 与 `vue-tsc typecheck` 均通过。

- Verified with a headless browser: before the fix, page-2 times duplicated page 1; after the fix, each page-2 message shows its own database `created` value.
- `eslint` and `vue-tsc typecheck` both pass.
