### PR TITLE
fix(web): 修复资源简介纯文本摘要的 markdown 剥离缺陷

### DIFF
--- a/apps/web/app/pages/galgame-rating/[id].vue
+++ b/apps/web/app/pages/galgame-rating/[id].vue
@@ -92,10 +92,7 @@ const jsonLd = computed<WithContext<Review> | null>(() => {
     publisher: publisherSchema,
     itemReviewed: itemReviewedSchema,
     reviewRating: reviewRatingSchema,
-    reviewBody: truncateRunes(
-      markdownToText(rating.short_summary || ''),
-      250
-    ).replace(/\\|\n/g, ''),
+    reviewBody: truncateRunes(markdownToText(rating.short_summary || ''), 250),
     interactionStatistic: [
       {
         '@type': 'InteractionCounter',
@@ -137,7 +134,7 @@ if (data.value) {
         ? markdownToText(data.value.short_summary)
         : `${data.value.user.name} 对 ${titleBase} 的评分 ${data.value.overall}/10`,
       175
-    ).replace(/\\|\n/g, '')
+    )
 
     useKunSeoMeta({
       title,

--- a/apps/web/app/pages/galgame/[gid]/index.vue
+++ b/apps/web/app/pages/galgame/[gid]/index.vue
@@ -66,10 +66,7 @@ if (galgame) {
       `${contentGenres.length ? `，题材包括${contentGenres.slice(0, 3).join('、')}` : ''}` +
       `。本页收录其基本资料、制作 Staff、登场角色与声优, 以及玩家评分与评价。`
 
-    const introText = truncateRunes(
-      markdownToText(galgame.intro_text),
-      175
-    ).replace(/\\|\n/g, '')
+    const introText = truncateRunes(markdownToText(galgame.intro_text), 175)
     const description = introText || fallbackDescription
 
     const jsonLd: WithContext<VideoGame> = {

--- a/apps/web/app/pages/toolset/[id]/index.vue
+++ b/apps/web/app/pages/toolset/[id]/index.vue
@@ -108,10 +108,7 @@ if (toolset) {
       commentCount: toolset.comment_count,
       comment: (toolset.comment_preview || []).map((c) => ({
         '@type': 'Comment',
-        text: truncateRunes((c.content as string) ?? '', 280).replace(
-          /\\|\n/g,
-          ''
-        ),
+        text: truncateRunes(markdownToText((c.content as string) ?? ''), 280),
         datePublished: new Date(c.created).toISOString(),
         author: { '@type': 'Person', name: c.user.name } as Person
       }))

--- a/apps/web/app/pages/topic/[id]/index.vue
+++ b/apps/web/app/pages/topic/[id]/index.vue
@@ -74,7 +74,7 @@ if (data.value) {
   const created = new Date(topic.created).toString()
   const updated = topic.edited ? new Date(topic.edited).toString() : ''
   const description = computed(() =>
-    truncateRunes(markdownToText(markdown).trim(), 233).replace(/\\|\n/g, '')
+    truncateRunes(markdownToText(markdown).trim(), 233)
   )
 
   const jsonLd = computed<WithContext<DiscussionForumPosting>>(() => {

--- a/apps/web/shared/utils/markdownToText.ts
+++ b/apps/web/shared/utils/markdownToText.ts
@@ -6,6 +6,10 @@ export const markdownToText = (
 ) => {
   if (!markdown) return ''
   const stripped = maskSpoilers(markdown)
+    .replace(/\\\\/g, '\uE000')
+    .replace(/\\\n/g, '\n')
+    .replace(/\\([\\`*_{}[\]()#+\-.!_>~|])/g, '$1')
+    .replace(/\uE000/g, '\\')
     .replace(/^[ \t]*```+.*$/gm, '')
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<[^>]+>/g, '')

--- a/apps/web/shared/utils/markdownToText.ts
+++ b/apps/web/shared/utils/markdownToText.ts
@@ -17,7 +17,7 @@ export const markdownToText = (
     .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
     .replace(/(\*\*|__)(.*?)\1/g, '$2')
     .replace(/~~(.*?)~~/g, '$1')
-    .replace(/(\*|_)(.*?)\1/g, '$2')
+    .replace(/(\*)(.*?)\1/g, '$2')
     .replace(/^\s*#{1,6}\s+(.*)/gm, '$1')
     .replace(/`/g, '')
     .replace(/^\s*(-{3,}|\*{3,}|_{3,})\s*$/gm, '')


### PR DESCRIPTION
## 修复 Galgame 资源简介 Markdown 渲染失效

### 问题背景

在 `/galgame/1389?tab=resource` 页面的资源列表卡片中，资源简介的纯文本摘要剥离不干净。用户编写的 Markdown 经 `markdownToText` 转为纯文本后，出现反斜杠残留（`\\\`）、URL 下划线被吞、行尾硬换行符 `\` 暴露等问题，导致摘要可读性差且链接被破坏。

### 根本原因

`apps/web/shared/utils/markdownToText.ts` 存在两个缺陷：

1. **未处理反斜杠转义和硬换行**：CommonMark 中 `\` 可作转义符（`\*`→`*`）或行尾硬换行（`\`+换行），原函数完全不处理，导致反斜杠原样残留
2. **斜体规则误吞 URL 下划线**：斜体剥离规则 `(\*|_)` 中的 `_` 会匹配 URL 中的下划线（如 `share_source`、`vd_source`），将其连同后续文本一起吞掉

此外，多处页面在 `markdownToText()` 后链式调用了 `.replace(/\\|\n/g, '')` 作为临时补丁，该补丁会删除用户文本中的字面反斜杠（如 Windows 路径 `C:\Users` → `C:Users`），属于同类 bug。

### 修改内容

**核心修复（`markdownToText.ts`）**

- 新增反斜杠处理链：保护 `\\`→占位符、丢弃硬换行 `\`+换行→换行、反转义 `\X`→`X`、恢复占位符
- 斜体规则从 `(\*|_)` 收窄为 `(\*)`，不再吞 URL 下划线

**清理冗余补丁（4 个文件）**

删除 `markdownToText()` 之后冗余的 `.replace(/\\|\n/g, '')`，该补丁在核心修复后已无作用（输出字节级一致），且会删除 `markdownToText` 正确保留的字面反斜杠：

- `pages/topic/[id]/index.vue` — SEO description
- `pages/galgame-rating/[id].vue` — JSON-LD reviewBody + SEO description（2 处）
- `pages/galgame/[gid]/index.vue` — SEO description

**修复 toolset 评论（`pages/toolset/[id]/index.vue`）**

JSON-LD `Comment.text` 原先直接输出后端 `ContentRaw`（原始 Markdown）+ `.replace(/\\|\n/g, '')`，与上述同类 bug。改为先经 `markdownToText` 处理，正确剥离 Markdown 语法、反转义反斜杠、折叠换行为空格。

### 影响评估

- **核心修复**：约 35 个 `markdownToText` 调用点均受益，已逐一回归检查
- **斜体取舍**：`_强调_` 在纯文本摘要中不再被剥离为 `强调`，这是修复 URL 下划线被吞的必要代价；Milkdown 编辑器渲染不受影响
- **字数统计**：`textCount` 为纯展示提示，±2 字差异不影响校验逻辑
- **TOC slug**：slug 仅用于列表显示和高亮匹配，滚动定位按 DOM 顺序扫描，不依赖 slug 字符串
- **JSON-LD 安全**：`JSON.stringify` 自动转义引号，HTML 标签（含 `<script>`）已被剥离，无 XSS 风险
- **typecheck / eslint**：5 个改动文件均通过

### 提交记录

1. `788769e8` — `markdownToText` 增加反斜杠转义和硬换行处理
2. `8ec05346` — `markdownToText` 斜体规则收窄，不再吞 URL 下划线
3. `e69b92ec` — 删除 topic SEO description 冗余 `.replace`
4. `e57bc936` — 删除 galgame-rating SEO/JSON-LD 冗余 `.replace`（2 处）
5. `a46ed23f` — 删除 galgame 详情页 SEO description 冗余 `.replace`
6. `18d86078` — toolset 评论 JSON-LD 改用 `markdownToText`

修改前：
<img width="818" height="520" alt="截屏2026-08-29 19 45 50" src="https://github.com/user-attachments/assets/77cd5eef-13aa-4b21-974a-dbf5f68f7377" />

修改后：

<img width="818" height="562" alt="截屏2026-08-29 19 48 37" src="https://github.com/user-attachments/assets/60f586c3-8701-4a98-afdd-116c86f2bdd5" />
