### PR TITLE
perf: redis read-through cache for catalog S2S + trgm search indexes

### DIFF
--- a/apps/api/internal/app/app.go
+++ b/apps/api/internal/app/app.go
@@ -178,7 +178,7 @@ func New(cfg *config.Config) *App {
 		cfg.NextMoeAPI.BaseURL,
 		cfg.NextMoeAPI.APIKey,
 		cfg.NextMoeAPI.ImageCDNBase,
-	)
+	).WithRedis(rdb)
 
 	newsCli := newsclient.New(newsclient.Config{
 		BaseURL: cfg.NewsAPI.BaseURL,

--- a/apps/api/internal/galgame/client/catalog_v2.go
+++ b/apps/api/internal/galgame/client/catalog_v2.go
@@ -217,6 +217,27 @@ func decodeOffsetCursor(cursor string) (int, bool) {
 func (c *GalgameClient) doV2(ctx context.Context, method, path string, query url.Values, body any) (int, []byte, *errors.AppError) {
 	v2Path := v2CatalogPath(path)
 	q := v2CatalogQuery(path, query)
+	var (
+		status   int
+		respBody []byte
+		appErr   *errors.AppError
+	)
+	if method == http.MethodGet {
+		status, respBody, appErr = c.getV2(ctx, v2Path, q)
+	} else {
+		status, respBody, appErr = c.doV2HTTP(ctx, method, v2Path, q, body)
+	}
+	if appErr != nil {
+		return status, respBody, appErr
+	}
+	out := rewriteV2JSON(respBody, c.imageCDNBase)
+	if method == http.MethodGet && status >= 200 && status < 300 {
+		out = c.spliceV2Subface(ctx, path, v2Path, query, out)
+	}
+	return status, out, nil
+}
+
+func (c *GalgameClient) doV2HTTP(ctx context.Context, method, v2Path string, q url.Values, body any) (int, []byte, *errors.AppError) {
 	reqURL := c.origin + v2Path
 	if len(q) > 0 {
 		reqURL += "?" + q.Encode()
@@ -250,11 +271,7 @@ func (c *GalgameClient) doV2(ctx context.Context, method, path string, query url
 	if err != nil {
 		return resp.StatusCode, nil, errors.ErrInternal("读取 Galgame 响应失败")
 	}
-	out := rewriteV2JSON(respBody, c.imageCDNBase)
-	if method == http.MethodGet && resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		out = c.spliceV2Subface(ctx, path, v2Path, query, out)
-	}
-	return resp.StatusCode, out, nil
+	return resp.StatusCode, respBody, nil
 }
 
 // v2 moved the character's works and the credit name's credits off their detail
@@ -321,30 +338,12 @@ func (c *GalgameClient) spliceV2Subface(
 }
 
 func (c *GalgameClient) getV2Raw(ctx context.Context, v2Path string, q url.Values) ([]byte, *errors.AppError) {
-	reqURL := c.origin + v2Path
-	if len(q) > 0 {
-		reqURL += "?" + q.Encode()
+	status, body, appErr := c.getV2(ctx, v2Path, q)
+	if appErr != nil {
+		return nil, appErr
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, errors.ErrInternal("创建请求失败")
-	}
-	if c.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		slog.Error("Galgame 服务请求失败 (传输层)",
-			"method", req.Method, "url", req.URL.String(), "error", err)
-		return nil, errors.ErrInternal(fmt.Sprintf("Galgame 服务不可达: %v", err))
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.ErrInternal("读取 Galgame 响应失败")
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, errors.New(errors.CodeBiz, "Galgame 资源不存在", resp.StatusCode)
+	if status < 200 || status >= 300 {
+		return nil, errors.New(errors.CodeBiz, "Galgame 资源不存在", status)
 	}
 	return rewriteV2JSON(body, c.imageCDNBase), nil
 }

--- a/apps/api/internal/galgame/client/catalog_v2_cache.go
+++ b/apps/api/internal/galgame/client/catalog_v2_cache.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"kun-galgame-api/pkg/errors"
+)
+
+const (
+	v2CacheKeyPrefix = "nmcache:v2:"
+	v2CacheMaxBody   = 512 << 10
+	v2CacheDetailTTL = 15 * time.Second
+	v2CacheListTTL   = 60 * time.Second
+)
+
+func v2CacheIdentity(v2Path string, q url.Values) string {
+	if len(q) > 0 {
+		return v2Path + "?" + q.Encode()
+	}
+	return v2Path
+}
+
+func v2CacheKey(v2Path string, q url.Values) string {
+	return v2CacheKeyPrefix + v2CacheIdentity(v2Path, q)
+}
+
+func v2CacheTTL(v2Path string) time.Duration {
+	for _, seg := range strings.Split(v2Path, "/") {
+		if seg != "" && v2SegmentIsNumericID(seg) {
+			return v2CacheDetailTTL
+		}
+	}
+	return v2CacheListTTL
+}
+
+func v2SegmentIsNumericID(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return s != ""
+}
+
+func (c *GalgameClient) getV2(ctx context.Context, v2Path string, q url.Values) (int, []byte, *errors.AppError) {
+	if body, ok := c.v2CacheGet(ctx, v2Path, q); ok {
+		return http.StatusOK, body, nil
+	}
+	status, body, appErr := c.doV2HTTP(ctx, http.MethodGet, v2Path, q, nil)
+	if appErr != nil {
+		return status, body, appErr
+	}
+	if status == http.StatusOK {
+		c.v2CacheSet(ctx, v2Path, q, body)
+	}
+	return status, body, nil
+}
+
+func (c *GalgameClient) v2CacheGet(ctx context.Context, v2Path string, q url.Values) ([]byte, bool) {
+	if c.rdb == nil {
+		return nil, false
+	}
+	body, err := c.rdb.Get(ctx, v2CacheKey(v2Path, q)).Bytes()
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+func (c *GalgameClient) v2CacheSet(ctx context.Context, v2Path string, q url.Values, body []byte) {
+	if c.rdb == nil || len(body) > v2CacheMaxBody {
+		return
+	}
+	if err := c.rdb.Set(ctx, v2CacheKey(v2Path, q), body, v2CacheTTL(v2Path)).Err(); err != nil {
+		return
+	}
+}

--- a/apps/api/internal/galgame/client/catalog_v2_cache_test.go
+++ b/apps/api/internal/galgame/client/catalog_v2_cache_test.go
@@ -1,0 +1,280 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+type v2Origin struct {
+	mu     sync.Mutex
+	hits   int
+	status int
+	body   []byte
+}
+
+func (o *v2Origin) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	o.mu.Lock()
+	o.hits++
+	status, body := o.status, o.body
+	o.mu.Unlock()
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+func (o *v2Origin) n() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.hits
+}
+
+func newV2CacheFixture(t *testing.T, redisOn bool) (*GalgameClient, *miniredis.Miniredis, *v2Origin) {
+	t.Helper()
+	o := &v2Origin{status: http.StatusOK, body: []byte(`{"ok":true}`)}
+	srv := httptest.NewServer(o)
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, "nmk_test", "")
+	var mr *miniredis.Miniredis
+	if redisOn {
+		mr = miniredis.RunT(t)
+		rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = rdb.Close() })
+		c.WithRedis(rdb)
+	}
+	return c, mr, o
+}
+
+func doV2CacheKey(path string, query url.Values) string {
+	return v2CacheKey(v2CatalogPath(path), v2CatalogQuery(path, query))
+}
+
+func TestV2CacheMissStoresAndHitServes(t *testing.T) {
+	c, mr, o := newV2CacheFixture(t, true)
+	ctx := context.Background()
+	path := "/catalog/works"
+	key := doV2CacheKey(path, nil)
+
+	_, body1, appErr := c.doV2(ctx, http.MethodGet, path, nil, nil)
+	if appErr != nil {
+		t.Fatalf("doV2 miss: %v", appErr)
+	}
+	if o.n() != 1 {
+		t.Fatalf("origin hits after miss = %d, want 1", o.n())
+	}
+	stored, err := mr.Get(key)
+	if err != nil {
+		t.Fatalf("miss did not store %s: %v", key, err)
+	}
+	if stored != `{"ok":true}` {
+		t.Fatalf("stored %q, want origin bytes", stored)
+	}
+
+	_, body2, appErr := c.doV2(ctx, http.MethodGet, path, nil, nil)
+	if appErr != nil {
+		t.Fatalf("doV2 hit: %v", appErr)
+	}
+	if o.n() != 1 {
+		t.Fatalf("origin hits after cache hit = %d, want 1", o.n())
+	}
+	if !bytes.Equal(body1, body2) {
+		t.Fatalf("hit body %q != miss body %q", body2, body1)
+	}
+}
+
+func TestV2RawCacheMissStoresAndHitServes(t *testing.T) {
+	c, mr, o := newV2CacheFixture(t, true)
+	ctx := context.Background()
+	v2Path := "/v2/catalog/works/123/covers"
+	key := v2CacheKey(v2Path, nil)
+
+	body1, appErr := c.getV2Raw(ctx, v2Path, nil)
+	if appErr != nil {
+		t.Fatalf("getV2Raw miss: %v", appErr)
+	}
+	if o.n() != 1 {
+		t.Fatalf("origin hits after miss = %d, want 1", o.n())
+	}
+	stored, err := mr.Get(key)
+	if err != nil {
+		t.Fatalf("miss did not store %s: %v", key, err)
+	}
+	if stored != `{"ok":true}` {
+		t.Fatalf("stored %q, want origin bytes", stored)
+	}
+
+	body2, appErr := c.getV2Raw(ctx, v2Path, nil)
+	if appErr != nil {
+		t.Fatalf("getV2Raw hit: %v", appErr)
+	}
+	if o.n() != 1 {
+		t.Fatalf("origin hits after cache hit = %d, want 1", o.n())
+	}
+	if !bytes.Equal(body1, body2) {
+		t.Fatalf("hit body %q != miss body %q", body2, body1)
+	}
+}
+
+func TestV2CacheSharedByDoV2AndGetV2Raw(t *testing.T) {
+	c, _, o := newV2CacheFixture(t, true)
+	ctx := context.Background()
+	_, _, appErr := c.doV2(ctx, http.MethodGet, "/catalog/works", nil, nil)
+	if appErr != nil {
+		t.Fatalf("doV2: %v", appErr)
+	}
+	raw, appErr := c.getV2Raw(ctx, "/v2/catalog/works", v2CatalogQuery("/catalog/works", nil))
+	if appErr != nil {
+		t.Fatalf("getV2Raw: %v", appErr)
+	}
+	if o.n() != 1 {
+		t.Fatalf("shared cache missed, origin hits = %d, want 1", o.n())
+	}
+	if string(raw) != `{"ok":true}` {
+		t.Fatalf("raw = %q", raw)
+	}
+}
+
+func TestV2CacheSkipsNon200(t *testing.T) {
+	c, mr, o := newV2CacheFixture(t, true)
+	o.status = http.StatusNotFound
+	o.body = []byte(`{"err":true}`)
+	ctx := context.Background()
+	path := "/catalog/works"
+	key := doV2CacheKey(path, nil)
+
+	status, _, appErr := c.doV2(ctx, http.MethodGet, path, nil, nil)
+	if appErr != nil {
+		t.Fatalf("doV2 404: %v", appErr)
+	}
+	if status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", status)
+	}
+	if _, err := mr.Get(key); err == nil {
+		t.Fatalf("non-200 was cached: %s", key)
+	}
+	if _, _, appErr = c.doV2(ctx, http.MethodGet, path, nil, nil); appErr != nil {
+		t.Fatalf("doV2 404 second: %v", appErr)
+	}
+	if o.n() != 2 {
+		t.Fatalf("doV2 origin hits after two 404s = %d, want 2", o.n())
+	}
+
+	_, appErr = c.getV2Raw(ctx, "/v2/catalog/works/1", nil)
+	if appErr == nil {
+		t.Fatal("getV2Raw 404: want error")
+	}
+	if _, err := mr.Get(v2CacheKey("/v2/catalog/works/1", nil)); err == nil {
+		t.Fatal("getV2Raw non-200 was cached")
+	}
+	if o.n() != 3 {
+		t.Fatalf("origin hits = %d, want 3", o.n())
+	}
+}
+
+func TestV2CacheSkipsLargeBody(t *testing.T) {
+	c, mr, o := newV2CacheFixture(t, true)
+	o.body = bytes.Repeat([]byte("a"), v2CacheMaxBody+1)
+	ctx := context.Background()
+	path := "/catalog/works"
+	key := doV2CacheKey(path, nil)
+
+	_, _, appErr := c.doV2(ctx, http.MethodGet, path, nil, nil)
+	if appErr != nil {
+		t.Fatalf("doV2 large: %v", appErr)
+	}
+	if _, err := mr.Get(key); err == nil {
+		t.Fatalf("body >512KiB was cached: %s", key)
+	}
+
+	_, _, appErr = c.doV2(ctx, http.MethodGet, path, nil, nil)
+	if appErr != nil {
+		t.Fatalf("doV2 large second: %v", appErr)
+	}
+	if o.n() != 2 {
+		t.Fatalf("origin hits = %d, want 2", o.n())
+	}
+}
+
+func TestV2CacheTTLClasses(t *testing.T) {
+	c, mr, _ := newV2CacheFixture(t, true)
+	ctx := context.Background()
+
+	if _, _, appErr := c.doV2(ctx, http.MethodGet, "/catalog/works", nil, nil); appErr != nil {
+		t.Fatalf("list: %v", appErr)
+	}
+	if _, _, appErr := c.doV2(ctx, http.MethodGet, "/catalog/works/9", nil, nil); appErr != nil {
+		t.Fatalf("detail: %v", appErr)
+	}
+	if _, appErr := c.getV2Raw(ctx, "/v2/catalog/works/9/covers", nil); appErr != nil {
+		t.Fatalf("subresource: %v", appErr)
+	}
+
+	listKey := doV2CacheKey("/catalog/works", nil)
+	detailKey := doV2CacheKey("/catalog/works/9", nil)
+	subKey := v2CacheKey("/v2/catalog/works/9/covers", nil)
+	if got := mr.TTL(listKey); got != v2CacheListTTL {
+		t.Fatalf("list TTL = %v, want %v", got, v2CacheListTTL)
+	}
+	if got := mr.TTL(detailKey); got != v2CacheDetailTTL {
+		t.Fatalf("detail TTL = %v, want %v", got, v2CacheDetailTTL)
+	}
+	if got := mr.TTL(subKey); got != v2CacheDetailTTL {
+		t.Fatalf("subresource TTL = %v, want %v", got, v2CacheDetailTTL)
+	}
+}
+
+func TestV2CacheNilRedisDisabled(t *testing.T) {
+	c, _, o := newV2CacheFixture(t, false)
+	ctx := context.Background()
+	if _, _, appErr := c.doV2(ctx, http.MethodGet, "/catalog/works", nil, nil); appErr != nil {
+		t.Fatalf("first: %v", appErr)
+	}
+	if _, _, appErr := c.doV2(ctx, http.MethodGet, "/catalog/works", nil, nil); appErr != nil {
+		t.Fatalf("second: %v", appErr)
+	}
+	if o.n() != 2 {
+		t.Fatalf("nil rdb origin hits = %d, want 2", o.n())
+	}
+}
+
+func TestV2CacheRedisDownFallthrough(t *testing.T) {
+	c, mr, o := newV2CacheFixture(t, true)
+	mr.Close()
+	ctx := context.Background()
+	if _, _, appErr := c.doV2(ctx, http.MethodGet, "/catalog/works", nil, nil); appErr != nil {
+		t.Fatalf("first with redis down: %v", appErr)
+	}
+	if _, _, appErr := c.doV2(ctx, http.MethodGet, "/catalog/works", nil, nil); appErr != nil {
+		t.Fatalf("second with redis down: %v", appErr)
+	}
+	if o.n() != 2 {
+		t.Fatalf("redis-down origin hits = %d, want 2", o.n())
+	}
+}
+
+func TestV2CacheTTL(t *testing.T) {
+	cases := []struct {
+		path string
+		ttl  time.Duration
+	}{
+		{"/v2/catalog/works", v2CacheListTTL},
+		{"/v2/catalog/works/123", v2CacheDetailTTL},
+		{"/v2/catalog/works/123/covers", v2CacheDetailTTL},
+		{"/v2/catalog/calendar", v2CacheListTTL},
+		{"/v2/catalog/search", v2CacheListTTL},
+		{"/v2/catalog/companies", v2CacheListTTL},
+		{"/v2/catalog/companies/5/graph", v2CacheDetailTTL},
+	}
+	for _, c := range cases {
+		if got := v2CacheTTL(c.path); got != c.ttl {
+			t.Errorf("v2CacheTTL(%q) = %v, want %v", c.path, got, c.ttl)
+		}
+	}
+}

--- a/apps/api/internal/galgame/client/client.go
+++ b/apps/api/internal/galgame/client/client.go
@@ -12,6 +12,8 @@ import (
 	"kun-galgame-api/internal/galgame/dto"
 	"kun-galgame-api/pkg/errors"
 	"kun-galgame-api/pkg/namepref"
+
+	"github.com/redis/go-redis/v9"
 )
 
 const briefCacheTTL = 2 * time.Minute
@@ -85,6 +87,7 @@ type GalgameClient struct {
 	httpClient   *http.Client
 	imageCDNBase string
 	imageMeta    ImageMetaResolver
+	rdb          *redis.Client
 
 	briefMu     sync.RWMutex
 	briefCache  map[batchCacheKey]batchCacheEntry[GalgameBrief]
@@ -134,6 +137,11 @@ func New(baseURL, apiKey, imageCDNBase string) *GalgameClient {
 		labelLinkCache: map[batchCacheKey]batchCacheEntry[string]{},
 		tagSexualCache: map[batchCacheKey]batchCacheEntry[bool]{},
 	}
+}
+
+func (c *GalgameClient) WithRedis(rdb *redis.Client) *GalgameClient {
+	c.rdb = rdb
+	return c
 }
 
 // CatalogGet reads a catalog face and returns the record with v2's shapes

--- a/apps/api/migrations/088_search_trgm_indexes.down.sql
+++ b/apps/api/migrations/088_search_trgm_indexes.down.sql
@@ -1,0 +1,11 @@
+-- 088 down: drop the search trgm indexes. Keep pg_trgm; other objects may use it.
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_topic_title_trgm;
+DROP INDEX IF EXISTS idx_topic_content_trgm;
+DROP INDEX IF EXISTS idx_topic_category_trgm;
+DROP INDEX IF EXISTS idx_topic_reply_content_trgm;
+DROP INDEX IF EXISTS idx_topic_comment_content_trgm;
+
+COMMIT;

--- a/apps/api/migrations/088_search_trgm_indexes.up.sql
+++ b/apps/api/migrations/088_search_trgm_indexes.up.sql
@@ -1,0 +1,32 @@
+-- 088: pg_trgm GIN indexes for forum search ILIKE '%kw%' queries.
+--
+-- WHY: SearchTopics (search_repo.go) ORs ILIKE across topic.title / topic.content
+-- / topic.category with no usable index — two seq scans per search (~300ms,
+-- slow-SQL). SearchReplies and SearchComments ILIKE the content columns on
+-- topic_reply and topic_comment. gin_trgm_ops supports leading-wildcard ILIKE.
+-- IF NOT EXISTS so this is a no-op where the orchestrator already built the
+-- indexes CONCURRENTLY on production.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- SearchTopics: (t.title ILIKE ? OR t.content ILIKE ? OR t.category ILIKE ?)
+CREATE INDEX IF NOT EXISTS idx_topic_title_trgm
+  ON topic USING gin (title gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_topic_content_trgm
+  ON topic USING gin (content gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_topic_category_trgm
+  ON topic USING gin (category gin_trgm_ops);
+
+-- SearchReplies: r.content ILIKE ? on topic_reply
+CREATE INDEX IF NOT EXISTS idx_topic_reply_content_trgm
+  ON topic_reply USING gin (content gin_trgm_ops);
+
+-- SearchComments: c.content ILIKE ? on topic_comment
+CREATE INDEX IF NOT EXISTS idx_topic_comment_content_trgm
+  ON topic_comment USING gin (content gin_trgm_ops);
+
+COMMIT;


### PR DESCRIPTION
## What

Two production-CPU countermeasures for the 2026-09-01 saturation incident (infra postgres at 1.3–2.8 cores, driven by this forum's 2.6–5.1M catalog v2 S2S calls/day):

1. **Read-through redis cache on `GalgameClient` v2 catalog GETs** — origin bytes cached under `nmcache:v2:<path>?<query>`, 200-only, ≤512KiB; TTL 15s for numeric-id paths (details/subresources), 60s for listings/search/calendar/taxonomy. `rewriteV2JSON`/`spliceV2Subface` still run per request on top of cached bytes; redis errors fall through to origin transparently; a nil redis client disables the cache (all `cmd/*` constructors unchanged).
2. **Migration 088: pg_trgm GIN indexes** on the five forum-search ILIKE columns (`topic.title/content/category`, `topic_reply.content`, `topic_comment.content`) — replaces two ~300ms seq scans per search. `IF NOT EXISTS`: production indexes are pre-built with `CREATE INDEX CONCURRENTLY` before deploy, so the migration no-ops there.

## Notes

- Staleness envelope: ≤15s on entity details, ≤60s on listings and the changes/redirects mirror feeds (cursor advancement mints fresh keys; only a re-read of the same tail page can be stale — benign for the sync cron).
- No singleflight: a TTL-expiry stampede costs at most a burst of what today is *every* request.
- **Migration to run on deploy**: `088_search_trgm_indexes` against the forum database (`kungalgame`), via the usual `go run ./cmd/migrate -dir up`.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD