### PR TITLE
fix(resource): Info-level for already-owned claims; remove dead Meilisearch config

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -50,11 +50,6 @@ FILE_STORAGE_BUCKET=
 FILE_STORAGE_ACCESS_KEY=
 FILE_STORAGE_SECRET_KEY=
 
-# Search (Meilisearch — dev stack :7700). The key MUST equal the stack's
-# MEILI_MASTER_KEY (docker-compose.dev.yml).
-MEILISEARCH_URL=http://127.0.0.1:7700
-MEILISEARCH_KEY=kun-dev-meili-master-key-local-only
-
 # NextMoe catalog galgame read surface (dev catalog instance :9281 or origin
 # :19281; host base, no path suffix). Public reads and user writes go to /v2
 # with Authorization: Bearer nmk_… . The only route still on the old family is

--- a/apps/api/internal/galgame/client/catalog_v2_test.go
+++ b/apps/api/internal/galgame/client/catalog_v2_test.go
@@ -50,7 +50,7 @@ func TestRewriteV2JSON_CoverAndBannerBecomeSlots(t *testing.T) {
 func TestV2CatalogQuery_EmptySearchGetsFacets(t *testing.T) {
 	q := v2CatalogQuery("/catalog/works/search", url.Values{"limit": {"24"}})
 	if q.Get("facets") != "olang,tag_id" {
-		t.Fatalf("facets = %q, want olang,tag_id so empty browse uses Meili total", q.Get("facets"))
+		t.Fatalf("facets = %q, want olang,tag_id so empty browse uses the search total", q.Get("facets"))
 	}
 	if q.Get("include_total") != "true" {
 		t.Fatalf("include_total = %q", q.Get("include_total"))

--- a/apps/api/internal/galgame/service/resource_service.go
+++ b/apps/api/internal/galgame/service/resource_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"log/slog"
+	"net/http"
 	"strconv"
 
 	"kun-galgame-api/internal/constants"
@@ -287,11 +288,19 @@ func (s *ResourceService) CreateResource(
 	return nil
 }
 
+func claimRefusedByState(appErr *errors.AppError) bool {
+	return appErr != nil && appErr.StatusCode == http.StatusConflict
+}
+
 func (s *ResourceService) claimOnFirstResource(ctx context.Context, accessToken string, gid int) {
 	if accessToken == "" || s.catalog == nil || !s.catalog.Configured() {
 		return
 	}
 	if _, appErr := adoptAndPublish(ctx, s.catalog, accessToken, int64(gid)); appErr != nil {
+		if claimRefusedByState(appErr) {
+			slog.Info("resource: catalog 作品已有归属, 跳过静默认领", "gid", gid)
+			return
+		}
 		slog.Warn("resource: 静默认领 catalog 作品失败", "gid", gid, "error", appErr)
 	}
 }

--- a/apps/api/internal/galgame/service/resource_service_test.go
+++ b/apps/api/internal/galgame/service/resource_service_test.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"kun-galgame-api/pkg/errors"
+)
+
+func TestClaimRefusedByState(t *testing.T) {
+	conflict := errors.New(errors.CodeBiz, `cannot claim a claim in state "live"`, http.StatusConflict)
+	if !claimRefusedByState(conflict) {
+		t.Fatalf("claimRefusedByState(409) = false, want true — a live claim is already owned, so the silent claim is skipped")
+	}
+	unavailable := errors.New(errors.CodeBiz, "资料库服务暂不可用", http.StatusServiceUnavailable)
+	if claimRefusedByState(unavailable) {
+		t.Fatalf("claimRefusedByState(503) = true, want false — an upstream outage must still WARN")
+	}
+	if claimRefusedByState(nil) {
+		t.Fatalf("claimRefusedByState(nil) = true, want false")
+	}
+}

--- a/apps/api/pkg/config/config.go
+++ b/apps/api/pkg/config/config.go
@@ -12,7 +12,6 @@ type Config struct {
 	Redis          RedisConfig
 	OAuth          OAuthConfig
 	FileStorage    S3Config
-	Search         SearchConfig
 	CORS           CORSConfig
 	NextMoeAPI     NextMoeAPIConfig
 	NewsAPI        NewsAPIConfig
@@ -147,11 +146,6 @@ type S3Config struct {
 	SecretKey string
 }
 
-type SearchConfig struct {
-	MeilisearchURL string
-	MeilisearchKey string
-}
-
 type CORSConfig struct {
 	AllowOrigins string
 }
@@ -217,10 +211,6 @@ func Load() (*Config, error) {
 			Bucket:    envOrDefault("FILE_STORAGE_BUCKET", ""),
 			AccessKey: envOrDefault("FILE_STORAGE_ACCESS_KEY", ""),
 			SecretKey: envOrDefault("FILE_STORAGE_SECRET_KEY", ""),
-		},
-		Search: SearchConfig{
-			MeilisearchURL: envOrDefault("MEILISEARCH_URL", "http://127.0.0.1:7700"),
-			MeilisearchKey: envOrDefault("MEILISEARCH_KEY", ""),
 		},
 		CORS: CORSConfig{
 			AllowOrigins: envOrDefault(

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,10 +10,10 @@
 # kungal app's **Dokploy Environment** via ${VAR}.
 #
 # Set in kungal's Dokploy Environment:
-#   POSTGRES_PASSWORD  OAUTH_CLIENT_SECRET  JWT_SECRET  MEILI_MASTER_KEY
+#   POSTGRES_PASSWORD  OAUTH_CLIENT_SECRET  JWT_SECRET
 #   (optional) KUN_IMAGE_CLIENT_ID/SECRET  FILE_STORAGE_* (B2 工具集)  MAIL_*
 # These MUST match infra's: POSTGRES_PASSWORD = infra POSTGRES_PASSWORD;
-# MEILI_MASTER_KEY = infra MEILI_MASTER_KEY; OAUTH_CLIENT_SECRET = 注册论坛 client 的明文.
+# OAUTH_CLIENT_SECRET = 注册论坛 client 的明文.
 # (JWT_SECRET here is kungal's OWN session secret — need NOT match infra.)
 #
 #   docker compose -f docker-compose.prod.yml pull
@@ -90,9 +90,6 @@ x-kungal-api-env: &kungal-api-env
   MAIL_USER: ${MAIL_USER:-}
   MAIL_PASSWORD: ${MAIL_PASSWORD:-}
   MAIL_FROM: ${MAIL_FROM:-}
-  # search — key MUST == infra MEILI_MASTER_KEY
-  MEILISEARCH_URL: http://meilisearch:7700
-  MEILISEARCH_KEY: ${MEILI_MASTER_KEY:?set MEILI_MASTER_KEY in Dokploy (= infra 的同名值)}
   # NextMoe catalog galgame read surface (host base with no path suffix): the
   # client calls {base}/v2/catalog/* with Authorization: Bearer nmk_… . The /v1
   # family is being retired upstream, so no suffix belongs on this value.

--- a/docker/api.env.example
+++ b/docker/api.env.example
@@ -41,10 +41,6 @@ FILE_STORAGE_BUCKET=
 FILE_STORAGE_ACCESS_KEY=
 FILE_STORAGE_SECRET_KEY=
 
-# Search (Meilisearch)
-MEILISEARCH_URL=http://meilisearch:7700
-MEILISEARCH_KEY=
-
 # NextMoe catalog galgame read surface (prod catalog :9281; host base with no
 # path suffix). The client calls {base}/v1/catalog/* with X-API-Key.
 KUN_NEXTMOE_API_BASE=http://catalog:9281


### PR DESCRIPTION
## What

**1. Silent-claim WARN noise.** After a user posts a download resource, `CreateResource` silently tries to claim + publish the catalog work for them. When the work is already `live`, catalog refuses with 409 and the forum logged that *expected* outcome as `WARN "resource: 静默认领 catalog 作品失败"` — ~110/day in production, in bursts (one user posting six resources for one game = six WARNs). This PR classifies a 409 `AppError` as "already owned" and logs it at Info; every other failure keeps the existing WARN. `adoptAndPublish` and the submission wizard are untouched.

**2. Dead Meilisearch config.** Meilisearch was retired platform-wide on 2026-09-01 (infra PR #114). The forum never read `MEILISEARCH_URL` / `MEILISEARCH_KEY` (zero consumers of the config fields), but `docker-compose.prod.yml` still required `MEILI_MASTER_KEY` through `${VAR:?}` — the next forum deploy fails at compose interpolation the moment the Dokploy panel drops that variable. Removed: the `SearchConfig` fields and env reads, the two compose lines (plus the header comments naming `MEILI_MASTER_KEY`), and both env examples. One stale test message reworded.

## Verification (local, CI-equivalent)

- `gofmt -l` clean · `go build ./...` · `go vet ./...` · `errcheck -exclude .errcheck-exclude ./...` clean
- `go test -count=1 ./...` → 39 packages ok, incl. new `TestClaimRefusedByState` (409 → skip, 503 → WARN, nil → false)
- `rg -i meili apps/api docker docker-compose.prod.yml` → no hits
- `docker compose -f docker-compose.prod.yml config` with dummy required vars → OK (no `MEILI_MASTER_KEY` needed anymore)

## Deploy note

**Merge this before the next forum deploy** if `MEILI_MASTER_KEY` has been removed/commented in the forum's Dokploy environment — otherwise that deploy fails on the `:?` guard. No migration.

## Not in this PR

- 38 stale Meilisearch mentions in prose only: `README.md` + `docs/readme/{chs,cht,jp}.md` (feature list, tech table, prerequisites) and historical plans under `docs/proj/`. The README/prerequisites lines are misleading for contributors and deserve a docs follow-up.
- `claimOnFirstResource` still fires on every resource post, not only the first; adjudicated as harmless (two cheap S2S calls) and left as is.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD