### PR TITLE
fix(galgame): tell the reader a narrow grant is narrow

### DIFF
--- a/apps/api/internal/galgame/service/collection_scope_err_test.go
+++ b/apps/api/internal/galgame/service/collection_scope_err_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"kun-galgame-api/pkg/catalogclient"
+	"kun-galgame-api/pkg/errors"
+)
+
+// The frontend keys its "sign in again" prompt on code 235 and nothing else;
+// 205 sends it down a path that re-checks this site's own cookie, finds it
+// healthy, and shows the reader nothing. Getting this pair wrong is invisible
+// in production, so it is asserted here rather than noticed later.
+func TestCollectionErrSeparatesANarrowGrantFromADeadSession(t *testing.T) {
+	scope := collectionErr(fmt.Errorf("reading folders: %w", catalogclient.ErrInsufficientScope), "读取收藏夹失败")
+	if scope == nil || scope.Code != errors.CodeReauthRequired {
+		t.Fatalf("a narrow grant must map to code %d, got %+v", errors.CodeReauthRequired, scope)
+	}
+
+	dead := collectionErr(fmt.Errorf("reading folders: %w", catalogclient.ErrUnauthorized), "读取收藏夹失败")
+	if dead == nil || dead.Code != errors.CodeAuth {
+		t.Fatalf("an expired session must map to code %d, got %+v", errors.CodeAuth, dead)
+	}
+
+	if scope.Code == dead.Code {
+		t.Fatal("the two faults must stay distinguishable to the client")
+	}
+}

--- a/apps/api/internal/galgame/service/collection_service.go
+++ b/apps/api/internal/galgame/service/collection_service.go
@@ -31,8 +31,9 @@ const previewCoversPerCollection = 4
 //
 // The token is the user's OAuth access token and must carry folder:read /
 // folder:write. A session minted before those scopes were requested is 403
-// SCOPE_REQUIRED upstream and surfaces here as ErrAuthExpired — a refresh
-// cannot widen a grant, so the only cure is signing in again.
+// SCOPE_REQUIRED upstream and surfaces here as ErrReauthRequired (code 235) —
+// a refresh cannot widen a grant, so the only cure is signing in again, and
+// that is the one message the reader can act on.
 type CollectionService struct {
 	collectionRepo *repository.GalgameCollectionRepository
 	galgameService *GalgameService
@@ -70,8 +71,17 @@ func collectionErr(err error, fallback string) *errors.AppError {
 		return nil
 	case stderrors.Is(err, catalogclient.ErrNotFound):
 		return errors.ErrNotFound("收藏夹不存在")
-	case stderrors.Is(err, catalogclient.ErrInsufficientScope),
-		stderrors.Is(err, catalogclient.ErrUnauthorized):
+	// A grant too narrow for folder:read and an expired session are different
+	// faults with different cures, and folding them together cost an outage on
+	// 2026-09-08: this returned code 205, whose client-side handler re-checks
+	// /api/user/status — which answers from this site's own cookie, finds it
+	// perfectly healthy, and returns without a word. Every collection read
+	// failed and nobody was told. Code 235 is what the five other scope-starved
+	// paths here already use (playtime, cover votes, edits, submissions, image
+	// upload) and its handler says the one thing that actually fixes it.
+	case stderrors.Is(err, catalogclient.ErrInsufficientScope):
+		return errors.ErrReauthRequired("收藏夹需要新的授权，请退出登录后重新登录以授予该权限")
+	case stderrors.Is(err, catalogclient.ErrUnauthorized):
 		return errors.ErrAuthExpired()
 	}
 	var apiErr *catalogclient.UserAPIError

--- a/apps/api/internal/galgame/service/galgame_service.go
+++ b/apps/api/internal/galgame/service/galgame_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	stderrors "errors"
 	"log/slog"
 	"strconv"
 
@@ -97,8 +98,12 @@ func (s *GalgameService) ToggleLike(
 }
 
 // The favourited half is every work in every folder the person owns, read from
-// the catalog with their own token. It is one call per folder — p50 is five —
-// and the browser asks for it once per session. A session with no token, or
+// the catalog with their own token. It is one call per folder, and the browser
+// asks for it once per session. This comment claimed "p50 is five" until the
+// distribution was actually measured on 2026-09-08: p50 is 1, p90 is 1, p99 is
+// 3, max 27. The 1+N here is not worth an upstream batch route — the folder
+// item face took 39 calls in the half hour that the list face took 1,221.
+// A session with no token, or
 // one minted before the folder scopes, gets its likes and an empty favourite
 // list rather than an error: the marks go missing, the page does not.
 func (s *GalgameService) GetMyInteractions(ctx context.Context, userID int, token string) dto.MyGalgameInteractions {
@@ -111,7 +116,11 @@ func (s *GalgameService) GetMyInteractions(ctx context.Context, userID int, toke
 	}
 	folders, err := s.catalog.MyFolders(ctx, token)
 	if err != nil {
-		slog.Warn("galgame: my folders unreadable", "user_id", userID, "err", err)
+		if stderrors.Is(err, catalogclient.ErrInsufficientScope) {
+			warnFoldersScope.warn("galgame: my folders unreadable, token lacks folder:read", "user_id", userID)
+		} else {
+			slog.Warn("galgame: my folders unreadable", "user_id", userID, "err", err)
+		}
 		return out
 	}
 	seen := map[int64]bool{}
@@ -121,7 +130,11 @@ func (s *GalgameService) GetMyInteractions(ctx context.Context, userID int, toke
 		}
 		items, iErr := s.catalog.MyFolderItems(ctx, token, f.ID)
 		if iErr != nil {
-			slog.Warn("galgame: folder items unreadable", "folder_id", f.ID, "err", iErr)
+			if stderrors.Is(iErr, catalogclient.ErrInsufficientScope) {
+				warnFoldersScope.warn("galgame: folder items unreadable, token lacks folder:read", "folder_id", f.ID)
+			} else {
+				slog.Warn("galgame: folder items unreadable", "folder_id", f.ID, "err", iErr)
+			}
 			return out
 		}
 		for _, it := range items {
@@ -144,7 +157,11 @@ func (s *GalgameService) isFavorited(ctx context.Context, token string, galgameI
 	}
 	folders, err := s.catalog.MyFoldersContaining(ctx, token, int64(galgameID))
 	if err != nil {
-		slog.Warn("galgame: favourite state unreadable", "galgame_id", galgameID, "err", err)
+		if stderrors.Is(err, catalogclient.ErrInsufficientScope) {
+			warnFavoriteScope.warn("galgame: favourite state unreadable, token lacks folder:read", "galgame_id", galgameID)
+		} else {
+			slog.Warn("galgame: favourite state unreadable", "galgame_id", galgameID, "err", err)
+		}
 		return false
 	}
 	return len(folders) > 0

--- a/apps/api/internal/galgame/service/playtime.go
+++ b/apps/api/internal/galgame/service/playtime.go
@@ -46,8 +46,13 @@ func (s *GalgameService) hydrateMyPlaytime(ctx context.Context, gid int, accessT
 	if err != nil {
 		// A token minted before playtime joined the authorize scope is the
 		// ordinary case here, not a fault: the detail page just shows no
-		// personal row until the user signs in again.
-		if !errors.Is(err, catalogclient.ErrInsufficientScope) {
+		// personal row until the user signs in again. It used to log nothing at
+		// all, and that is how the 2026-09-08 folder-scope outage stayed
+		// invisible on the sibling call sites for an hour — so it is counted now
+		// rather than swallowed.
+		if errors.Is(err, catalogclient.ErrInsufficientScope) {
+			warnPlaytimeScope.warn("galgame detail: own playtime unavailable, token lacks playtime:read", "gid", gid)
+		} else {
 			slog.Warn("galgame detail: own playtime unavailable", "gid", gid, "error", err)
 		}
 		return nil

--- a/apps/api/internal/galgame/service/scope_warn.go
+++ b/apps/api/internal/galgame/service/scope_warn.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"log/slog"
+	"sync/atomic"
+	"time"
+)
+
+// A token that predates a newly shipped scope is the ordinary case for a while,
+// and the two obvious ways to log it are both wrong. On 2026-09-08 the folder
+// scopes shipped with the collections cutover: every read 403'd for the 95,286
+// sessions minted before that day, and `isFavorited` logged one WARN per call —
+// ~30k lines a day of noise nobody could read. `playtime.go` had already gone
+// the other way and logged nothing at all, which is why the same outage ran for
+// an hour with no alert and no user report: the marks simply went missing.
+//
+// So: one line a minute, carrying the count it swallowed. Silence means zero,
+// and a nonzero count is a number somebody can act on.
+type scopeWarn struct {
+	last      atomic.Int64
+	swallowed atomic.Int64
+}
+
+// One per call site, so a starved scope on the detail page cannot hide behind
+// the session-level read having already logged this minute.
+var (
+	warnFoldersScope  scopeWarn
+	warnFavoriteScope scopeWarn
+	warnPlaytimeScope scopeWarn
+)
+
+func (w *scopeWarn) warn(msg string, args ...any) {
+	now := time.Now().Unix()
+	last := w.last.Load()
+	if now-last < 60 || !w.last.CompareAndSwap(last, now) {
+		w.swallowed.Add(1)
+		return
+	}
+	slog.Warn(msg, append(args, "swallowed_since_last", w.swallowed.Swap(0))...)
+}


### PR DESCRIPTION
The collections cutover (#166) moved every favourite read onto `/v2/me/folders`, which demands `folder:read`. An OAuth grant is fixed at authorization and a refresh cannot widen it, so every session minted before that scope shipped answered `403 SCOPE_REQUIRED`.

Measured on production 2026-09-08: **22 live first-party sessions carried `folder:read`, 95,286 did not** (46,617 people), and the route ran at **85% failure** — 1,515 × 403 against 265 × 200. The refresh TTL is 90 days, so it would not have healed on its own. That half is already fixed in the database (the existing grants were widened for the two `auto_consent` first-party clients, and the route has been at zero 403 since 06:27Z).

This PR fixes the two reasons **nobody noticed for an hour**.

### 1. The reader was never told

`collectionErr` folded `SCOPE_REQUIRED` into `ErrAuthExpired` (code 205). The client handler for 205 waits 1.5s, then re-checks `/api/user/status` to confirm the session really died — but that endpoint answers from this site's **own cookie**, which was perfectly healthy. So `dead` was always false and the handler returned without a word: no toast, no sign-out, no prompt. The user just saw an empty favourites list.

Code 235 (`ErrReauthRequired`) is what the five other scope-starved paths here already use — playtime, cover votes, edits, submissions, image upload — and its handler says the one thing that actually fixes it. The cutover simply didn't follow the pattern that already existed.

A test pins the 205/235 pair, because getting it wrong is invisible in production.

### 2. The logs were unreadable in both directions

The degrading read paths logged one WARN per call — about **30k lines a day** of noise. `playtime.go` had gone the other way and logged *nothing*, which is how this ran for an hour with no alert.

Neither extreme is right. `scope_warn` emits **one line a minute carrying the count it swallowed**: silence means zero, and a nonzero count is a number somebody can act on. `playtime.go` moves onto it too, so the previously silent site is counted rather than swallowed.

### Also: a comment that was measurably wrong

`GetMyInteractions`' comment claimed the folder count per user has "p50 five", implying a fan-out worth an upstream batch route. Measured on production the same day: **p50 1, p90 1, p99 3, max 27**, and the folder-item face took **39** calls in the half hour the list face took **1,221**. There is no fan-out here worth batching — the opposite of what the comment implied. Corrected rather than acted on.

### Verification

`gofmt` clean, `go build ./...` clean, `go vet` clean, `go test ./internal/galgame/service/` green (including the new test).

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
