### PR TITLE
feat(playtime): wire the play-status selector to catalog work-states and fix the dead sweep

### DIFF
--- a/apps/api/internal/galgame/dto/galgame_dto.go
+++ b/apps/api/internal/galgame/dto/galgame_dto.go
@@ -300,11 +300,9 @@ type GalgameDetail struct {
 	MyPlaytime                 *GalgameMyPlaytime       `json:"my_playtime,omitempty"`
 }
 
-// Clients counts the applications the viewer has reported this work from —
-// catalog folds them with MAX(minutes), because two apps watching one save
-// file are not two playthroughs.
+// Status is the work-state word for this work, or empty when the user has none.
+// The v2 single playtime read carries no client count.
 type GalgameMyPlaytime struct {
 	Minutes int    `json:"minutes"`
 	Status  string `json:"status"`
-	Clients int    `json:"clients"`
 }

--- a/apps/api/internal/galgame/dto/playtime_dto.go
+++ b/apps/api/internal/galgame/dto/playtime_dto.go
@@ -1,16 +1,10 @@
 package dto
 
 type PlaytimeMineItem struct {
-	Galgame      GalgameListCard `json:"galgame"`
-	Minutes      int             `json:"minutes"`
-	Status       string          `json:"status"`
-	LastPlayedAt string          `json:"last_played_at,omitempty"`
-	UpdatedAt    string          `json:"updated_at"`
-	Clients      int             `json:"clients"`
-	// True when the largest report on this work came from an application other
-	// than the forum — a desktop tracker the user authorised themselves. The
-	// forum must never silently overwrite one of those.
-	External bool `json:"external"`
+	Galgame GalgameListCard `json:"galgame"`
+	Minutes int             `json:"minutes"`
+	Status  string          `json:"status"`
+	Clients int             `json:"clients"`
 }
 
 type PlaytimeMinePage struct {

--- a/apps/api/internal/galgame/handler/playtime_handler.go
+++ b/apps/api/internal/galgame/handler/playtime_handler.go
@@ -31,10 +31,10 @@ type reportPlaytimeRequest struct {
 }
 
 var playtimeStatuses = map[string]bool{
-	catalogclient.PlaytimeStatusPlaying:  true,
-	catalogclient.PlaytimeStatusFinished: true,
-	catalogclient.PlaytimeStatusDropped:  true,
-	catalogclient.PlaytimeStatusOnHold:   true,
+	catalogclient.WorkStateDoing:   true,
+	catalogclient.WorkStateDone:    true,
+	catalogclient.WorkStateOnHold:  true,
+	catalogclient.WorkStateDropped: true,
 }
 
 func (h *PlaytimeHandler) Report(c fiber.Ctx) error {
@@ -53,7 +53,7 @@ func (h *PlaytimeHandler) Report(c fiber.Ctx) error {
 		return response.Error(c, errors.ErrBadRequest("游玩时长超出可记录的范围"))
 	}
 	if req.Status == "" {
-		req.Status = catalogclient.PlaytimeStatusPlaying
+		req.Status = catalogclient.WorkStateDoing
 	}
 	if !playtimeStatuses[req.Status] {
 		return response.Error(c, errors.ErrBadRequest("未知的游玩状态"))

--- a/apps/api/internal/galgame/handler/playtime_handler_test.go
+++ b/apps/api/internal/galgame/handler/playtime_handler_test.go
@@ -27,7 +27,7 @@ type fakePlaytimeFace struct {
 	// What the self-read reports back after the write. A second application of
 	// the same user can hold a larger number than the one just written.
 	foldMinutes int
-	foldClients int
+	workState   string
 }
 
 func (f *fakePlaytimeFace) server(t *testing.T) *httptest.Server {
@@ -50,14 +50,32 @@ func (f *fakePlaytimeFace) server(t *testing.T) *httptest.Server {
 			_, _ = w.Write([]byte(f.body))
 			return
 		}
-		if r.Method == http.MethodGet {
-			_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":{"work_id":1000,"minutes":` +
-				strconv.Itoa(f.foldMinutes) + `,"status":"finished","last_played_at":null,"clients":` +
-				strconv.Itoa(f.foldClients) + `}}`))
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/work-states") {
+			if r.Method == http.MethodGet {
+				if f.workState != "" {
+					_, _ = w.Write([]byte(f.workState))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			state, _ := body["state"].(string)
+			comp := "null"
+			if v, ok := body["completion"]; ok {
+				b, _ := json.Marshal(v)
+				comp = string(b)
+			}
+			_, _ = w.Write([]byte(`{"object":"work_state","work_id":"1000","state":"` + state +
+				`","completion":` + comp + `,"created_at":"2026-08-20T00:00:00Z","updated_at":"2026-08-20T00:00:00Z"}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":{"work_id":1000,"minutes":720,` +
-			`"status":"finished","client_id":"forum","updated_at":"2026-08-20T00:00:00Z"}}`))
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":{"work_id":1000,"minutes":` +
+				strconv.Itoa(f.foldMinutes) + `}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":{"work_id":1000,"minutes":720}}`))
 	}))
 	t.Cleanup(srv.Close)
 	return srv
@@ -84,19 +102,22 @@ func playtimeTestApp(t *testing.T, catalogURL string, user *middleware.UserInfo)
 }
 
 func TestReportPlaytimeTravelsAsTheUserAndAnswersTheFold(t *testing.T) {
-	fake := &fakePlaytimeFace{foldMinutes: 900, foldClients: 2}
+	fake := &fakePlaytimeFace{foldMinutes: 900}
 	app := playtimeTestApp(t, fake.server(t).URL, plainUser)
 
 	status, raw := doJSON(t, app, "PUT", "/api/galgame/1/playtime",
-		`{"minutes":720,"status":"finished"}`)
+		`{"minutes":720,"status":"done"}`)
 	if status != http.StatusOK {
 		t.Fatalf("report: status = %d body %s", status, raw)
 	}
 
-	if len(fake.requests) != 2 {
-		t.Fatalf("want a write then a fold read, got %+v", fake.requests)
+	if len(fake.requests) != 4 {
+		t.Fatalf("want work-state read, playtime write, work-state write, playtime fold, got %+v", fake.requests)
 	}
-	write := fake.requests[0]
+	if fake.requests[0].Method != http.MethodGet || fake.requests[0].Path != "/v2/me/work-states/1000" {
+		t.Errorf("work-state read = %s %s", fake.requests[0].Method, fake.requests[0].Path)
+	}
+	write := fake.requests[1]
 	if write.Method != http.MethodPut || write.Path != "/v2/me/playtimes/1000" {
 		t.Errorf("write went to %s %s, want PUT /v2/me/playtimes/1000", write.Method, write.Path)
 	}
@@ -106,15 +127,28 @@ func TestReportPlaytimeTravelsAsTheUserAndAnswersTheFold(t *testing.T) {
 	if write.Body["minutes"] != float64(720) {
 		t.Errorf("body = %v", write.Body)
 	}
-	read := fake.requests[1]
+	if _, ok := write.Body["status"]; ok {
+		t.Errorf("playtime PUT must not send status, got %v", write.Body)
+	}
+	ws := fake.requests[2]
+	if ws.Method != http.MethodPut || ws.Path != "/v2/me/work-states/1000" {
+		t.Errorf("work-state write = %s %s", ws.Method, ws.Path)
+	}
+	if ws.Body["state"] != "done" {
+		t.Errorf("work-state body = %v", ws.Body)
+	}
+	if _, ok := ws.Body["completion"]; ok {
+		t.Errorf("no prior completion, PUT must omit it, got %v", ws.Body)
+	}
+	read := fake.requests[3]
 	if read.Method != http.MethodGet || read.Path != "/v2/me/playtimes/1000" {
 		t.Errorf("fold read = %s %s", read.Method, read.Path)
 	}
 
 	var env struct {
 		Data struct {
-			Minutes int `json:"minutes"`
-			Clients int `json:"clients"`
+			Minutes int    `json:"minutes"`
+			Status  string `json:"status"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(raw, &env); err != nil {
@@ -122,8 +156,31 @@ func TestReportPlaytimeTravelsAsTheUserAndAnswersTheFold(t *testing.T) {
 	}
 	// 900, not the 720 just written: another app of the same user holds more,
 	// and echoing our own figure would contradict the number on the page.
-	if env.Data.Minutes != 900 || env.Data.Clients != 2 {
-		t.Errorf("answered %+v, want the folded 900 over 2 clients", env.Data)
+	if env.Data.Minutes != 900 || env.Data.Status != "done" {
+		t.Errorf("answered %+v, want the folded 900 with stored state done", env.Data)
+	}
+}
+
+func TestReportPlaytimePreservesUpstreamCompletion(t *testing.T) {
+	fake := &fakePlaytimeFace{
+		foldMinutes: 720,
+		workState:   `{"object":"work_state","work_id":"1000","state":"doing","completion":"all","created_at":"2026-08-01T00:00:00Z","updated_at":"2026-08-01T00:00:00Z"}`,
+	}
+	app := playtimeTestApp(t, fake.server(t).URL, plainUser)
+
+	status, raw := doJSON(t, app, "PUT", "/api/galgame/1/playtime",
+		`{"minutes":720,"status":"done"}`)
+	if status != http.StatusOK {
+		t.Fatalf("report: status = %d body %s", status, raw)
+	}
+	var put map[string]any
+	for _, req := range fake.requests {
+		if req.Method == http.MethodPut && strings.Contains(req.Path, "/work-states") {
+			put = req.Body
+		}
+	}
+	if put["state"] != "done" || put["completion"] != "all" {
+		t.Errorf("work-state PUT = %v, want state=done and completion=all preserved", put)
 	}
 }
 
@@ -135,6 +192,8 @@ func TestReportPlaytimeRejectsBadInputWithoutCallingCatalog(t *testing.T) {
 		{"negative", `{"minutes":-1}`},
 		{"over the ceiling", `{"minutes":60001}`},
 		{"unknown status", `{"minutes":600,"status":"finished_all"}`},
+		{"wish", `{"minutes":600,"status":"wish"}`},
+		{"old word", `{"minutes":600,"status":"playing"}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -159,7 +218,7 @@ func TestReportPlaytimeAsksForReauthOnAScopeDenial(t *testing.T) {
 	}
 	app := playtimeTestApp(t, fake.server(t).URL, plainUser)
 
-	status, raw := doJSON(t, app, "PUT", "/api/galgame/1/playtime", `{"minutes":720,"status":"finished"}`)
+	status, raw := doJSON(t, app, "PUT", "/api/galgame/1/playtime", `{"minutes":720,"status":"done"}`)
 	if status != http.StatusForbidden {
 		t.Fatalf("status = %d body %s", status, raw)
 	}

--- a/apps/api/internal/galgame/service/playtime.go
+++ b/apps/api/internal/galgame/service/playtime.go
@@ -12,12 +12,11 @@ import (
 	apperrors "kun-galgame-api/pkg/errors"
 )
 
-// One sweep of the upstream sync face. Its page size is 200 and it orders by
-// updated_at ascending, so a library larger than this cannot be shown newest
-// first without pulling all of it.
+// v2 /me/playtimes refuses limit>100 (400 LIMIT_TOO_LARGE) and pages with cursor=, not updated_since=.
 const (
-	playtimeSweepPage  = 200
-	playtimeSweepPages = 5
+	playtimeSweepPage  = 100
+	playtimeSweepPages = 10
+	workStateBatch     = 100
 )
 
 // Catalog has no delete endpoint: a report is withdrawn by dropping it under
@@ -60,7 +59,14 @@ func (s *GalgameService) hydrateMyPlaytime(ctx context.Context, gid int, accessT
 	if got == nil || playtimeWithdrawn(got.Minutes) {
 		return nil
 	}
-	return &dto.GalgameMyPlaytime{Minutes: got.Minutes, Status: got.Status, Clients: got.Clients}
+	status := ""
+	ws, err := s.catalog.MyWorkState(ctx, accessToken, workID)
+	if err != nil {
+		slog.Warn("galgame detail: own work-state unavailable", "gid", gid, "error", err)
+	} else if ws != nil {
+		status = ws.State
+	}
+	return &dto.GalgameMyPlaytime{Minutes: got.Minutes, Status: status}
 }
 
 type PlaytimeService struct {
@@ -99,34 +105,65 @@ func (s *PlaytimeService) Report(
 	if !ok {
 		return nil, apperrors.ErrNotFound("条目不存在")
 	}
-	if _, err := s.catalog.ReportPlaytime(ctx, accessToken, workID,
-		catalogclient.PlaytimeReport{Minutes: minutes, Status: status}); err != nil {
+	if minutes == 0 {
+		if _, err := s.catalog.ReportPlaytime(ctx, accessToken, workID,
+			catalogclient.PlaytimeReport{Minutes: 0}); err != nil {
+			return nil, err
+		}
+		return s.foldedMyPlaytime(ctx, accessToken, workID, 0, "")
+	}
+
+	current, err := s.catalog.MyWorkState(ctx, accessToken, workID)
+	if err != nil {
 		return nil, err
 	}
-	// Read the fold back rather than echoing what we just wrote: another
-	// application of the same user may hold a larger number, and catalog keeps
-	// the largest. Showing the forum's own figure would contradict the page.
+	if _, err := s.catalog.ReportPlaytime(ctx, accessToken, workID,
+		catalogclient.PlaytimeReport{Minutes: minutes}); err != nil {
+		return nil, err
+	}
+	// An omitted completion on PUT clears the stored value, so echo a non-null one back.
+	var completion *string
+	if current != nil {
+		completion = current.Completion
+	}
+	stored, err := s.catalog.PutWorkState(ctx, accessToken, workID, status, completion)
+	if err != nil {
+		return nil, err
+	}
+	state := status
+	if stored != nil && stored.State != "" {
+		state = stored.State
+	}
+	return s.foldedMyPlaytime(ctx, accessToken, workID, minutes, state)
+}
+
+func (s *PlaytimeService) foldedMyPlaytime(
+	ctx context.Context,
+	accessToken string,
+	workID int64,
+	writtenMinutes int,
+	status string,
+) (*dto.GalgameMyPlaytime, error) {
 	got, err := s.catalog.MyPlaytime(ctx, accessToken, workID)
 	if err != nil || got == nil {
-		if playtimeWithdrawn(minutes) {
+		if playtimeWithdrawn(writtenMinutes) {
 			return nil, nil
 		}
-		return &dto.GalgameMyPlaytime{Minutes: minutes, Status: status, Clients: 1}, nil
+		return &dto.GalgameMyPlaytime{Minutes: writtenMinutes, Status: status}, nil
 	}
 	if playtimeWithdrawn(got.Minutes) {
 		return nil, nil
 	}
-	return &dto.GalgameMyPlaytime{Minutes: got.Minutes, Status: got.Status, Clients: got.Clients}, nil
+	return &dto.GalgameMyPlaytime{Minutes: got.Minutes, Status: status}, nil
 }
 
 type foldedPlaytime struct {
-	gid          int
-	minutes      int
-	status       string
-	lastPlayedAt string
-	updatedAt    string
-	clients      int
-	external     bool
+	gid       int
+	workID    int64
+	minutes   int
+	clients   int
+	lastIndex int
+	status    string
 }
 
 func (s *PlaytimeService) ListMine(
@@ -140,7 +177,17 @@ func (s *PlaytimeService) ListMine(
 		return nil, err
 	}
 	folded := s.fold(ctx, rows)
-	sort.Slice(folded, func(i, j int) bool { return folded[i].updatedAt > folded[j].updatedAt })
+
+	ids := make([]int64, 0, len(folded))
+	for _, f := range folded {
+		ids = append(ids, f.workID)
+	}
+	states, err := s.workStatesByIDs(ctx, accessToken, ids)
+	if err != nil {
+		return nil, err
+	}
+	attachWorkStates(folded, states)
+	sort.Slice(folded, func(i, j int) bool { return folded[i].lastIndex > folded[j].lastIndex })
 
 	out := &dto.PlaytimeMinePage{
 		Items:     []dto.PlaytimeMineItem{},
@@ -149,7 +196,7 @@ func (s *PlaytimeService) ListMine(
 	}
 	for _, f := range folded {
 		out.TotalMinutes += f.minutes
-		if f.status == catalogclient.PlaytimeStatusFinished {
+		if f.status == catalogclient.WorkStateDone {
 			out.FinishedWorks++
 		}
 	}
@@ -179,13 +226,10 @@ func (s *PlaytimeService) ListMine(
 			continue
 		}
 		out.Items = append(out.Items, dto.PlaytimeMineItem{
-			Galgame:      card,
-			Minutes:      f.minutes,
-			Status:       f.status,
-			LastPlayedAt: f.lastPlayedAt,
-			UpdatedAt:    f.updatedAt,
-			Clients:      f.clients,
-			External:     f.external,
+			Galgame: card,
+			Minutes: f.minutes,
+			Status:  f.status,
+			Clients: f.clients,
 		})
 	}
 	return out, nil
@@ -208,41 +252,50 @@ func (s *PlaytimeService) sweep(ctx context.Context, accessToken string) ([]cata
 	return all, true, nil
 }
 
-// foldRecords collapses the per-(work, client) rows the sync face returns into
-// one row per work, the same way catalog's own self-read does: MAX minutes, and
-// finished wins over every other status.
-func foldRecords(rows []catalogclient.PlaytimeRecord, forumClientID string) ([]int64, map[int64]foldedPlaytime) {
+func foldRecords(rows []catalogclient.PlaytimeRecord) ([]int64, map[int64]foldedPlaytime) {
 	byWork := make(map[int64]foldedPlaytime, len(rows))
 	order := make([]int64, 0, len(rows))
-	for _, r := range rows {
+	for i, r := range rows {
 		cur, ok := byWork[r.WorkID]
 		if !ok {
 			order = append(order, r.WorkID)
 		}
+		cur.workID = r.WorkID
 		cur.clients++
 		if r.Minutes >= cur.minutes {
 			cur.minutes = r.Minutes
-			cur.external = r.ClientID != forumClientID
-			if cur.status != catalogclient.PlaytimeStatusFinished {
-				cur.status = r.Status
-			}
 		}
-		if r.Status == catalogclient.PlaytimeStatusFinished {
-			cur.status = catalogclient.PlaytimeStatusFinished
-		}
-		if r.LastPlayedAt != nil && *r.LastPlayedAt > cur.lastPlayedAt {
-			cur.lastPlayedAt = *r.LastPlayedAt
-		}
-		if r.UpdatedAt > cur.updatedAt {
-			cur.updatedAt = r.UpdatedAt
-		}
+		cur.lastIndex = i
 		byWork[r.WorkID] = cur
 	}
 	return order, byWork
 }
 
+func attachWorkStates(folded []foldedPlaytime, states map[int64]catalogclient.WorkStateRecord) {
+	for i := range folded {
+		if rec, ok := states[folded[i].workID]; ok {
+			folded[i].status = rec.State
+		}
+	}
+}
+
+func (s *PlaytimeService) workStatesByIDs(ctx context.Context, accessToken string, ids []int64) (map[int64]catalogclient.WorkStateRecord, error) {
+	out := make(map[int64]catalogclient.WorkStateRecord, len(ids))
+	for i := 0; i < len(ids); i += workStateBatch {
+		end := min(i+workStateBatch, len(ids))
+		got, err := s.catalog.MyWorkStates(ctx, accessToken, ids[i:end])
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range got {
+			out[k] = v
+		}
+	}
+	return out, nil
+}
+
 func (s *PlaytimeService) fold(ctx context.Context, rows []catalogclient.PlaytimeRecord) []foldedPlaytime {
-	order, byWork := foldRecords(rows, s.forumClientID)
+	order, byWork := foldRecords(rows)
 	gidByWork, appErr := s.galgameClient.GIDsByCatalogIDs(ctx, order)
 	if appErr != nil {
 		return nil

--- a/apps/api/internal/galgame/service/playtime_test.go
+++ b/apps/api/internal/galgame/service/playtime_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"sort"
 	"testing"
 
 	"kun-galgame-api/pkg/catalogclient"
@@ -8,15 +9,12 @@ import (
 
 func TestFoldRecords_CollapsesClientsTheWayCatalogDoes(t *testing.T) {
 	rows := []catalogclient.PlaytimeRecord{
-		{WorkID: 7, Minutes: 300, Status: catalogclient.PlaytimeStatusFinished,
-			ClientID: "forum", UpdatedAt: "2026-08-01T00:00:00Z", LastPlayedAt: ptr("2026-07-30T00:00:00Z")},
-		{WorkID: 7, Minutes: 720, Status: catalogclient.PlaytimeStatusPlaying,
-			ClientID: "tracker", UpdatedAt: "2026-08-09T00:00:00Z", LastPlayedAt: ptr("2026-08-08T00:00:00Z")},
-		{WorkID: 9, Minutes: 60, Status: catalogclient.PlaytimeStatusDropped,
-			ClientID: "forum", UpdatedAt: "2026-08-05T00:00:00Z"},
+		{WorkID: 7, Minutes: 300},
+		{WorkID: 7, Minutes: 720},
+		{WorkID: 9, Minutes: 60},
 	}
 
-	order, byWork := foldRecords(rows, "forum")
+	order, byWork := foldRecords(rows)
 	if len(order) != 2 || order[0] != 7 || order[1] != 9 {
 		t.Fatalf("order = %v, want [7 9]", order)
 	}
@@ -25,34 +23,28 @@ func TestFoldRecords_CollapsesClientsTheWayCatalogDoes(t *testing.T) {
 	if seven.minutes != 720 {
 		t.Errorf("minutes = %d, want the larger 720", seven.minutes)
 	}
-	if seven.status != catalogclient.PlaytimeStatusFinished {
-		t.Errorf("status = %q, want finished to survive a later playing row", seven.status)
-	}
 	if seven.clients != 2 {
 		t.Errorf("clients = %d, want 2", seven.clients)
 	}
-	if !seven.external {
-		t.Error("external = false, want true when the largest report is another app's")
-	}
-	if seven.lastPlayedAt != "2026-08-08T00:00:00Z" {
-		t.Errorf("lastPlayedAt = %q, want the latest of the two", seven.lastPlayedAt)
-	}
-	if seven.updatedAt != "2026-08-09T00:00:00Z" {
-		t.Errorf("updatedAt = %q, want the latest of the two", seven.updatedAt)
+	if seven.lastIndex != 1 {
+		t.Errorf("lastIndex = %d, want 1", seven.lastIndex)
 	}
 
 	nine := byWork[9]
-	if nine.external {
-		t.Error("external = true for a forum-only row")
+	if nine.clients != 1 {
+		t.Errorf("clients = %d, want 1", nine.clients)
 	}
-	if nine.status != catalogclient.PlaytimeStatusDropped {
-		t.Errorf("status = %q, want dropped", nine.status)
+	if nine.lastIndex != 2 {
+		t.Errorf("lastIndex = %d, want 2", nine.lastIndex)
+	}
+
+	folded := []foldedPlaytime{seven, nine}
+	sort.Slice(folded, func(i, j int) bool { return folded[i].lastIndex > folded[j].lastIndex })
+	if folded[0].workID != 9 || folded[1].workID != 7 {
+		t.Errorf("order by last occurrence = %d,%d want 9 then 7", folded[0].workID, folded[1].workID)
 	}
 }
 
-// A cleared record is not deleted upstream — it is written down to 0 and the
-// aggregate stops counting it. The profile page counted it anyway and printed
-// "1 部作品 · 合计 · 已通关 1 部" for a work with nothing left to show.
 func TestPlaytimeWithdrawn_TreatsASubFloorReportAsAbsent(t *testing.T) {
 	cases := []struct {
 		minutes int
@@ -70,18 +62,43 @@ func TestPlaytimeWithdrawn_TreatsASubFloorReportAsAbsent(t *testing.T) {
 	}
 }
 
-// The fold takes MAX across a user's clients, so a work is withdrawn only when
-// EVERY client is under the floor: clearing the forum's own row must not hide a
-// desktop tracker's live one.
 func TestFoldRecords_KeepsAWorkAnotherClientStillReports(t *testing.T) {
 	rows := []catalogclient.PlaytimeRecord{
-		{WorkID: 7, Minutes: 0, Status: catalogclient.PlaytimeStatusFinished,
-			ClientID: "forum", UpdatedAt: "2026-08-10T00:00:00Z"},
-		{WorkID: 7, Minutes: 480, Status: catalogclient.PlaytimeStatusPlaying,
-			ClientID: "tracker", UpdatedAt: "2026-08-09T00:00:00Z"},
+		{WorkID: 7, Minutes: 0},
+		{WorkID: 7, Minutes: 480},
 	}
-	_, byWork := foldRecords(rows, "forum")
+	_, byWork := foldRecords(rows)
 	if playtimeWithdrawn(byWork[7].minutes) {
-		t.Errorf("folded minutes = %d, want the tracker's 480 to keep the work visible", byWork[7].minutes)
+		t.Errorf("folded minutes = %d, want the other client's 480 to keep the work visible", byWork[7].minutes)
+	}
+}
+
+func TestAttachWorkStates_JoinsStatusAndLeavesGapsEmpty(t *testing.T) {
+	folded := []foldedPlaytime{
+		{workID: 7, minutes: 720},
+		{workID: 9, minutes: 60},
+		{workID: 11, minutes: 100},
+	}
+	attachWorkStates(folded, map[int64]catalogclient.WorkStateRecord{
+		7: {WorkID: 7, State: catalogclient.WorkStateDone},
+		9: {WorkID: 9, State: catalogclient.WorkStateDoing},
+	})
+	if folded[0].status != catalogclient.WorkStateDone {
+		t.Errorf("work 7 status = %q, want done", folded[0].status)
+	}
+	if folded[1].status != catalogclient.WorkStateDoing {
+		t.Errorf("work 9 status = %q, want doing", folded[1].status)
+	}
+	if folded[2].status != "" {
+		t.Errorf("work 11 status = %q, want empty when missing", folded[2].status)
+	}
+	finished := 0
+	for _, f := range folded {
+		if f.status == catalogclient.WorkStateDone {
+			finished++
+		}
+	}
+	if finished != 1 {
+		t.Errorf("finished = %d, want 1", finished)
 	}
 }

--- a/apps/api/pkg/catalogclient/user_playtime.go
+++ b/apps/api/pkg/catalogclient/user_playtime.go
@@ -10,13 +10,6 @@ import (
 	"strconv"
 )
 
-const (
-	PlaytimeStatusPlaying  = "playing"
-	PlaytimeStatusFinished = "finished"
-	PlaytimeStatusDropped  = "dropped"
-	PlaytimeStatusOnHold   = "on_hold"
-)
-
 // Catalog refuses anything above this, and its aggregate job ignores anything
 // below PlaytimeMinutesFloor — a report under the floor is stored but never
 // reaches the public median, which is how a user withdraws one.
@@ -26,25 +19,17 @@ const (
 )
 
 type PlaytimeReport struct {
-	Minutes int    `json:"minutes"`
-	Status  string `json:"status,omitempty"`
+	Minutes int `json:"minutes"`
 }
 
 type PlaytimeRecord struct {
-	WorkID       int64   `json:"work_id"`
-	Minutes      int     `json:"minutes"`
-	Status       string  `json:"status"`
-	LastPlayedAt *string `json:"last_played_at"`
-	ClientID     string  `json:"client_id"`
-	UpdatedAt    string  `json:"updated_at"`
+	WorkID  int64 `json:"work_id"`
+	Minutes int   `json:"minutes"`
 }
 
 type PlaytimeSelf struct {
-	WorkID       int64   `json:"work_id"`
-	Minutes      int     `json:"minutes"`
-	Status       string  `json:"status"`
-	LastPlayedAt *string `json:"last_played_at"`
-	Clients      int     `json:"clients"`
+	WorkID  int64 `json:"work_id"`
+	Minutes int   `json:"minutes"`
 }
 
 func (c *Client) ReportPlaytime(ctx context.Context, accessToken string, workID int64,
@@ -55,7 +40,7 @@ func (c *Client) ReportPlaytime(ctx context.Context, accessToken string, workID 
 	if err := c.userV2JSON(ctx, http.MethodPut, accessToken, path, map[string]any{"minutes": report.Minutes}, &out, nil); err != nil {
 		return nil, err
 	}
-	return &PlaytimeRecord{WorkID: parseFlexID(out.WorkID), Minutes: out.Minutes, Status: out.Status, UpdatedAt: out.UpdatedAt}, nil
+	return &PlaytimeRecord{WorkID: parseFlexID(out.WorkID), Minutes: out.Minutes}, nil
 }
 
 // MyPlaytime answers (nil, nil) when the user has never reported on this work.
@@ -92,18 +77,18 @@ func (c *Client) MyPlaytime(ctx context.Context, accessToken string, workID int6
 	if parseFlexID(out.WorkID) == 0 && out.Minutes == 0 {
 		return nil, nil
 	}
-	return &PlaytimeSelf{WorkID: parseFlexID(out.WorkID), Minutes: out.Minutes, Status: out.Status, LastPlayedAt: out.LastPlayedAt, Clients: out.Clients}, nil
+	return &PlaytimeSelf{WorkID: parseFlexID(out.WorkID), Minutes: out.Minutes}, nil
 }
 
 // ListMyPlaytime pages the caller's own rows oldest-change-first, returning the
-// cursor to hand back as updatedSince. One row per (work, client): the same work
-// appears once per application that reported it.
-func (c *Client) ListMyPlaytime(ctx context.Context, accessToken, updatedSince string,
+// next cursor. One row per (work, client): the same work appears once per
+// application that reported it.
+func (c *Client) ListMyPlaytime(ctx context.Context, accessToken, cursor string,
 	limit int) ([]PlaytimeRecord, string, error) {
 
 	q := url.Values{}
-	if updatedSince != "" {
-		q.Set("updated_since", updatedSince)
+	if cursor != "" {
+		q.Set("cursor", cursor)
 	}
 	if limit > 0 {
 		q.Set("limit", strconv.Itoa(limit))
@@ -119,7 +104,7 @@ func (c *Client) ListMyPlaytime(ctx context.Context, accessToken, updatedSince s
 	rows := out.rows()
 	items := make([]PlaytimeRecord, 0, len(rows))
 	for _, it := range rows {
-		items = append(items, PlaytimeRecord{WorkID: parseFlexID(it.WorkID), Minutes: it.Minutes, Status: it.Status, UpdatedAt: it.UpdatedAt})
+		items = append(items, PlaytimeRecord{WorkID: parseFlexID(it.WorkID), Minutes: it.Minutes})
 	}
 	return items, out.cursor(), nil
 }

--- a/apps/api/pkg/catalogclient/user_playtime_test.go
+++ b/apps/api/pkg/catalogclient/user_playtime_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 )
 
@@ -18,7 +20,7 @@ func TestReportPlaytime_ForwardsBearerAndBody(t *testing.T) {
 		raw, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(raw, &gotBody)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"code":0,"data":{"work_id":7,"minutes":720,"status":"finished","client_id":"forum","updated_at":"2026-08-20T00:00:00Z"}}`))
+		_, _ = w.Write([]byte(`{"code":0,"data":{"work_id":7,"minutes":720}}`))
 	}))
 	defer srv.Close()
 
@@ -26,7 +28,7 @@ func TestReportPlaytime_ForwardsBearerAndBody(t *testing.T) {
 	// need the s2s credentials the rest of catalogclient carries.
 	c := New(Config{BaseURL: srv.URL})
 	got, err := c.ReportPlaytime(context.Background(), "user-jwt", 7,
-		PlaytimeReport{Minutes: 720, Status: PlaytimeStatusFinished})
+		PlaytimeReport{Minutes: 720})
 	if err != nil {
 		t.Fatalf("ReportPlaytime: %v", err)
 	}
@@ -41,6 +43,9 @@ func TestReportPlaytime_ForwardsBearerAndBody(t *testing.T) {
 	}
 	if gotBody["minutes"] != float64(720) {
 		t.Errorf("body = %v, want the absolute minutes", gotBody)
+	}
+	if _, ok := gotBody["status"]; ok {
+		t.Errorf("playtime PUT must not send status, got %v", gotBody)
 	}
 	if got.Minutes != 720 {
 		t.Errorf("record = %+v", got)
@@ -100,26 +105,123 @@ func TestPlaytime_ScopeDenialIsDistinctFromForbidden(t *testing.T) {
 }
 
 func TestListMyPlaytime_PassesCursorAndReturnsNext(t *testing.T) {
-	var gotQuery string
+	var gotQuery url.Values
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotQuery = r.URL.RawQuery
+		gotQuery = r.URL.Query()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"code":0,"data":{"items":[{"work_id":7,"minutes":120,"status":"playing","client_id":"forum","updated_at":"2026-08-02T00:00:00Z"}],"cursor":"2026-08-02T00:00:00Z"}}`))
+		_, _ = w.Write([]byte(`{"code":0,"data":{"items":[{"work_id":7,"minutes":120}],"next_cursor":"abc"}}`))
 	}))
 	defer srv.Close()
 
 	items, cursor, err := New(Config{BaseURL: srv.URL}).ListMyPlaytime(
-		context.Background(), "user-jwt", "2026-08-01T00:00:00Z", 200)
+		context.Background(), "user-jwt", "abc-prev", 100)
 	if err != nil {
 		t.Fatalf("ListMyPlaytime: %v", err)
 	}
-	if gotQuery != "limit=200&updated_since=2026-08-01T00%3A00%3A00Z" {
-		t.Errorf("query = %q", gotQuery)
+	if gotQuery.Get("cursor") != "abc-prev" {
+		t.Errorf("cursor param = %q", gotQuery.Get("cursor"))
 	}
-	if len(items) != 1 || items[0].WorkID != 7 {
+	if len(gotQuery) != 2 {
+		t.Errorf("query = %v, want only cursor and limit", gotQuery)
+	}
+	limit, err := strconv.Atoi(gotQuery.Get("limit"))
+	if err != nil || limit <= 0 || limit > 100 {
+		t.Errorf("limit = %q, want 1–100", gotQuery.Get("limit"))
+	}
+	if len(items) != 1 || items[0].WorkID != 7 || items[0].Minutes != 120 {
 		t.Errorf("items = %+v", items)
 	}
-	if cursor != "2026-08-02T00:00:00Z" {
+	if cursor != "abc" {
 		t.Errorf("cursor = %q", cursor)
+	}
+}
+
+func TestMyWorkState_NotFoundIsNone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	got, err := New(Config{BaseURL: srv.URL}).MyWorkState(context.Background(), "user-jwt", 7)
+	if err != nil {
+		t.Fatalf("MyWorkState: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("got %+v, want nil — never having set a state is a 404", got)
+	}
+}
+
+func TestPutWorkState_OmitsNilCompletionAndEchoes(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"work_state","work_id":"7","state":"done","completion":null,"created_at":"2026-08-20T00:00:00Z","updated_at":"2026-08-20T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	got, err := New(Config{BaseURL: srv.URL}).PutWorkState(
+		context.Background(), "user-jwt", 7, WorkStateDone, nil)
+	if err != nil {
+		t.Fatalf("PutWorkState: %v", err)
+	}
+	if gotBody["state"] != WorkStateDone {
+		t.Errorf("body = %v", gotBody)
+	}
+	if _, ok := gotBody["completion"]; ok {
+		t.Errorf("nil completion must be omitted, got %v", gotBody)
+	}
+	if got == nil || got.WorkID != 7 || got.State != WorkStateDone || got.Completion != nil {
+		t.Errorf("record = %+v", got)
+	}
+}
+
+func TestPutWorkState_SendsCompletionWhenSet(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"work_state","work_id":"7","state":"done","completion":"all","created_at":"2026-08-20T00:00:00Z","updated_at":"2026-08-20T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	all := "all"
+	got, err := New(Config{BaseURL: srv.URL}).PutWorkState(
+		context.Background(), "user-jwt", 7, WorkStateDone, &all)
+	if err != nil {
+		t.Fatalf("PutWorkState: %v", err)
+	}
+	if gotBody["completion"] != "all" {
+		t.Errorf("body = %v, want completion echoed", gotBody)
+	}
+	if got == nil || got.Completion == nil || *got.Completion != "all" {
+		t.Errorf("record = %+v", got)
+	}
+}
+
+func TestMyWorkStates_ParsesItemsAndIgnoresMissing(t *testing.T) {
+	var gotIDs string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIDs = r.URL.Query().Get("work_ids")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","items":[{"object":"work_state","work_id":"7","state":"done","completion":null}],"missing":["9"]}`))
+	}))
+	defer srv.Close()
+
+	got, err := New(Config{BaseURL: srv.URL}).MyWorkStates(
+		context.Background(), "user-jwt", []int64{7, 9})
+	if err != nil {
+		t.Fatalf("MyWorkStates: %v", err)
+	}
+	if gotIDs != "7,9" {
+		t.Errorf("work_ids = %q, want 7,9", gotIDs)
+	}
+	if rec, ok := got[7]; !ok || rec.State != WorkStateDone {
+		t.Errorf("got[7] = %+v", got[7])
+	}
+	if _, ok := got[9]; ok {
+		t.Errorf("missing id 9 must not appear, got %+v", got)
 	}
 }

--- a/apps/api/pkg/catalogclient/user_work_state.go
+++ b/apps/api/pkg/catalogclient/user_work_state.go
@@ -1,0 +1,90 @@
+package catalogclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	WorkStateWish    = "wish"
+	WorkStateDoing   = "doing"
+	WorkStateDone    = "done"
+	WorkStateOnHold  = "on_hold"
+	WorkStateDropped = "dropped"
+)
+
+type WorkStateRecord struct {
+	WorkID     int64   `json:"work_id"`
+	State      string  `json:"state"`
+	Completion *string `json:"completion"`
+}
+
+func workStateRecord(out v2WorkState) WorkStateRecord {
+	return WorkStateRecord{
+		WorkID:     parseFlexID(out.WorkID),
+		State:      out.State,
+		Completion: out.Completion,
+	}
+}
+
+func (c *Client) MyWorkState(ctx context.Context, accessToken string, workID int64) (*WorkStateRecord, error) {
+	path := "/v2/me/work-states/" + strconv.FormatInt(workID, 10)
+	var out v2WorkState
+	if err := c.userV2JSON(ctx, http.MethodGet, accessToken, path, nil, &out, nil); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if parseFlexID(out.WorkID) == 0 && out.State == "" {
+		return nil, nil
+	}
+	rec := workStateRecord(out)
+	return &rec, nil
+}
+
+func (c *Client) PutWorkState(ctx context.Context, accessToken string, workID int64, state string, completion *string) (*WorkStateRecord, error) {
+	path := "/v2/me/work-states/" + strconv.FormatInt(workID, 10)
+	body := struct {
+		State      string  `json:"state"`
+		Completion *string `json:"completion,omitempty"`
+	}{
+		State:      state,
+		Completion: completion,
+	}
+	var out v2WorkState
+	if err := c.userV2JSON(ctx, http.MethodPut, accessToken, path, body, &out, nil); err != nil {
+		return nil, err
+	}
+	rec := workStateRecord(out)
+	return &rec, nil
+}
+
+func (c *Client) MyWorkStates(ctx context.Context, accessToken string, workIDs []int64) (map[int64]WorkStateRecord, error) {
+	out := make(map[int64]WorkStateRecord, len(workIDs))
+	if len(workIDs) == 0 {
+		return out, nil
+	}
+	ids := make([]string, len(workIDs))
+	for i, id := range workIDs {
+		ids[i] = strconv.FormatInt(id, 10)
+	}
+	q := url.Values{}
+	q.Set("work_ids", strings.Join(ids, ","))
+	var page v2List[v2WorkState]
+	if err := c.userV2JSON(ctx, http.MethodGet, accessToken, "/v2/me/work-states?"+q.Encode(), nil, &page, nil); err != nil {
+		return nil, err
+	}
+	for _, it := range page.rows() {
+		rec := workStateRecord(it)
+		if rec.WorkID == 0 {
+			continue
+		}
+		out[rec.WorkID] = rec
+	}
+	return out, nil
+}

--- a/apps/api/pkg/catalogclient/v2_user.go
+++ b/apps/api/pkg/catalogclient/v2_user.go
@@ -342,12 +342,16 @@ func (s v2Snapshot) values() map[string]any {
 }
 
 type v2Playtime struct {
-	WorkID       json.RawMessage `json:"work_id"`
-	Minutes      int             `json:"minutes"`
-	Status       string          `json:"status"`
-	Clients      int             `json:"clients"`
-	LastPlayedAt *string         `json:"last_played_at"`
-	UpdatedAt    string          `json:"updated_at"`
+	WorkID  json.RawMessage `json:"work_id"`
+	Minutes int             `json:"minutes"`
+}
+
+type v2WorkState struct {
+	WorkID     json.RawMessage `json:"work_id"`
+	State      string          `json:"state"`
+	Completion *string         `json:"completion"`
+	CreatedAt  string          `json:"created_at"`
+	UpdatedAt  string          `json:"updated_at"`
 }
 
 type v2CoverVote struct {

--- a/apps/web/app/components/galgame/header/Playtime.vue
+++ b/apps/web/app/components/galgame/header/Playtime.vue
@@ -3,7 +3,7 @@ import {
   KUN_GALGAME_PLAYTIME_SOURCE_CONST,
   KUN_GALGAME_PLAYTIME_SOURCE_MAP,
   KUN_GALGAME_PLAYTIME_STATUS_MAP,
-  type KunGalgamePlaytimeStatus
+  type KunGalgameWorkState
 } from '~/constants/galgame-playtime'
 
 const props = defineProps<{
@@ -51,16 +51,16 @@ const myDuration = computed(() => formatDurationMinutes(mine.value?.minutes))
 const myTooltip = computed(() => {
   if (!mine.value) return '记录你在这部作品上的游玩时长'
   const status =
-    KUN_GALGAME_PLAYTIME_STATUS_MAP[
-      mine.value.status as KunGalgamePlaytimeStatus
-    ] ?? ''
-  const parts = [`你的记录: ${myDuration.value} · ${status}`]
+    KUN_GALGAME_PLAYTIME_STATUS_MAP[mine.value.status as KunGalgameWorkState] ??
+    ''
+  const parts = [
+    status
+      ? `你的记录: ${myDuration.value} · ${status}`
+      : `你的记录: ${myDuration.value}`
+  ]
   const site = props.galgame.playtimes?.find((p) => p.source === 'nextmoe')
   if (site) {
     parts.push(`本站中位数 ${formatDurationMinutes(site.minutes)}`)
-  }
-  if (mine.value.clients > 1) {
-    parts.push(`${mine.value.clients} 个应用在记录, 取其中最长的一条`)
   }
   return parts.join(', ')
 })
@@ -106,11 +106,6 @@ const openEditor = () => {
         <KunIcon :name="mine ? 'lucide:user-round' : 'lucide:timer'" />
         <template v-if="mine">
           <span class="tabular-nums">{{ myDuration }}</span>
-          <KunIcon
-            v-if="mine.clients > 1"
-            name="lucide:monitor-smartphone"
-            class="text-default-400"
-          />
         </template>
         <template v-else>记录我的时长</template>
       </KunButton>

--- a/apps/web/app/components/galgame/header/PlaytimeModal.vue
+++ b/apps/web/app/components/galgame/header/PlaytimeModal.vue
@@ -2,6 +2,7 @@
 import {
   KUN_GALGAME_PLAYTIME_HOURS_MAX,
   KUN_GALGAME_PLAYTIME_MINUTES_FLOOR,
+  KUN_GALGAME_PLAYTIME_STATUS_CONST,
   KUN_GALGAME_PLAYTIME_STATUS_OPTIONS,
   type KunGalgamePlaytimeStatus
 } from '~/constants/galgame-playtime'
@@ -18,12 +19,16 @@ const emits = defineEmits<{
 const open = defineModel<boolean>({ required: true })
 
 const hours = ref(0)
-const status = ref<KunGalgamePlaytimeStatus>('playing')
+const status = ref<KunGalgamePlaytimeStatus>('doing')
 
 watch(open, (isOpen) => {
   if (!isOpen) return
   hours.value = props.mine ? Math.round((props.mine.minutes / 60) * 10) / 10 : 0
-  status.value = (props.mine?.status ?? 'playing') as KunGalgamePlaytimeStatus
+  const current = props.mine?.status ?? ''
+  const allowed = KUN_GALGAME_PLAYTIME_STATUS_CONST as readonly string[]
+  status.value = allowed.includes(current)
+    ? (current as KunGalgamePlaytimeStatus)
+    : 'doing'
 })
 
 const minutes = computed(() => Math.round((Number(hours.value) || 0) * 60))
@@ -113,12 +118,6 @@ const clear = async () => {
         color="warning"
         title="超出上限"
         :description="`单部作品最多可记录 ${KUN_GALGAME_PLAYTIME_HOURS_MAX} 小时。`"
-      />
-      <KunInfo
-        v-else-if="mine && mine.clients > 1"
-        color="info"
-        title="不止一个应用在记录"
-        :description="`你有 ${mine.clients} 个应用在记录这部作品, 展示的是其中最长的一条。这里只会覆盖本站这一条。`"
       />
       <p v-else class="text-default-500 text-sm">
         只有「已通关」的记录会计入本站中位数, 且需要至少 3 位玩家上报。

--- a/apps/web/app/components/user/Playtime.vue
+++ b/apps/web/app/components/user/Playtime.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {
   KUN_GALGAME_PLAYTIME_STATUS_MAP,
-  type KunGalgamePlaytimeStatus
+  type KunGalgameWorkState
 } from '~/constants/galgame-playtime'
 
 const pageData = reactive({ page: 1, limit: 24 })
@@ -21,7 +21,7 @@ const summary = computed(() => {
 })
 
 const statusColor = (value: string) =>
-  value === 'finished' ? 'success' : value === 'dropped' ? 'danger' : 'default'
+  value === 'done' ? 'success' : value === 'dropped' ? 'danger' : 'default'
 </script>
 
 <template>
@@ -69,20 +69,11 @@ const statusColor = (value: string) =>
           <span class="font-medium tabular-nums">
             {{ formatDurationMinutes(item.minutes) }}
           </span>
-          <div class="flex items-center gap-1">
-            <KunTooltip
-              v-if="item.external"
-              text="这条记录来自你授权的其它应用, 不是在本站填写的"
-            >
-              <KunIcon
-                name="lucide:monitor-smartphone"
-                class="text-default-400"
-              />
-            </KunTooltip>
+          <div v-if="item.status" class="flex items-center gap-1">
             <KunChip size="sm" variant="flat" :color="statusColor(item.status)">
               {{
                 KUN_GALGAME_PLAYTIME_STATUS_MAP[
-                  item.status as KunGalgamePlaytimeStatus
+                  item.status as KunGalgameWorkState
                 ] ?? item.status
               }}
             </KunChip>

--- a/apps/web/app/constants/galgame-playtime.ts
+++ b/apps/web/app/constants/galgame-playtime.ts
@@ -46,8 +46,8 @@ export const KUN_GALGAME_PLAYTIME_SOURCE_MAP: Record<
 }
 
 export const KUN_GALGAME_PLAYTIME_STATUS_CONST = [
-  'playing',
-  'finished',
+  'doing',
+  'done',
   'on_hold',
   'dropped'
 ] as const
@@ -55,19 +55,22 @@ export const KUN_GALGAME_PLAYTIME_STATUS_CONST = [
 export type KunGalgamePlaytimeStatus =
   (typeof KUN_GALGAME_PLAYTIME_STATUS_CONST)[number]
 
+export type KunGalgameWorkState = KunGalgamePlaytimeStatus | 'wish'
+
 export const KUN_GALGAME_PLAYTIME_STATUS_MAP: Record<
-  KunGalgamePlaytimeStatus,
+  KunGalgameWorkState,
   string
 > = {
-  playing: '游玩中',
-  finished: '已通关',
+  doing: '游玩中',
+  done: '已通关',
   on_hold: '搁置中',
-  dropped: '已弃坑'
+  dropped: '已弃坑',
+  wish: '想玩'
 }
 
 export const KUN_GALGAME_PLAYTIME_STATUS_OPTIONS = [
-  { value: 'playing', label: '游玩中', icon: 'lucide:play' },
-  { value: 'finished', label: '已通关', icon: 'lucide:flag' },
+  { value: 'doing', label: '游玩中', icon: 'lucide:play' },
+  { value: 'done', label: '已通关', icon: 'lucide:flag' },
   { value: 'on_hold', label: '搁置中', icon: 'lucide:pause' },
   { value: 'dropped', label: '已弃坑', icon: 'lucide:x' }
 ] as const

--- a/apps/web/shared/types/galgame.ts
+++ b/apps/web/shared/types/galgame.ts
@@ -100,7 +100,6 @@ export interface GalgamePlaytime {
 export interface GalgameMyPlaytime {
   minutes: number
   status: string
-  clients: number
 }
 
 export interface GalgameIntro {
@@ -207,10 +206,7 @@ export interface PlaytimeMineItem {
   galgame: GalgameCard
   minutes: number
   status: string
-  last_played_at?: string
-  updated_at: string
   clients: number
-  external: boolean
 }
 
 export interface PlaytimeMinePage {

--- a/docs/proj/playtime.md
+++ b/docs/proj/playtime.md
@@ -6,19 +6,23 @@
 
 | 层                                                              | 位置                                                      | 谁能读                                                     |
 | --------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------- |
-| 逐条上报 `catalog_user_playtime(actor_uid, work_id, client_id)` | catalog                                                   | 只有本人（`/v1/playtime/mine`、`/v1/playtime/works/{id}`） |
-| 跨应用折叠                                                      | catalog 读时计算，`MAX(minutes)`，`finished` 压过其它状态 | 只有本人                                                   |
+| 逐条上报 `catalog_user_playtime(actor_uid, work_id, client_id)` | catalog                                                   | 只有本人（`GET /v2/me/playtimes`、`GET /v2/me/playtimes/{id}`） |
+| 跨应用折叠                                                      | catalog 读时计算，`MAX(minutes)`                          | 只有本人                                                   |
 | 公开中位数 `catalog_work_playtime(source_id = nextmoe)`         | catalog，`jobs/userplaytime` 夜跑写                       | 所有人（`GET /v1/catalog/works/{id}` 的 `playtimes`）      |
 
-公开那一层的门槛由 infra 定：只统计 `status = finished`、每人取跨应用 `MAX`、`minutes ∈ [10, 60000]`、`percentile_disc(0.5)`、**至少 3 位上报者**，不够格的行会被删掉。论坛不复制这套判断，只在前端画 `minVotes` 那条线（`constants/galgame-playtime.ts`）。
+公开那一层的门槛由 infra 定：只统计 `state = done` 的上报者、每人取跨应用 `MAX`、`minutes ∈ [10, 60000]`、`percentile_disc(0.5)`、**至少 3 位上报者**，不够格的行会被删掉。论坛不复制这套判断，只在前端画 `minVotes` 那条线（`constants/galgame-playtime.ts`）。
 
 ## 论坛这一侧
 
 - 授权 scope 在 `apps/web/app/utils/oauth-auth.ts`：`playtime:read playtime:write`。这两个 scope 在 infra 是 self-service，不需要申请。
 - 老 token 里没有它们，upstream 回 403，`catalogclient.ErrInsufficientScope` → `errors.ErrReauthRequired`，提示重新登录。和 `catalog:edit` 当初一样，不做全站 session bump。
-- 写：`PUT /galgame/:gid/playtime`（`minutes` 是**绝对累计值，不是增量**；`minutes = 0` 就是撤回）。写完再读一次折叠值回来，因为用户的其它应用可能报了更大的数，直接回显自己写的会和页面上的数字打架。
+- 写：`PUT /galgame/:gid/playtime`（`minutes` 是**绝对累计值，不是增量**；`minutes = 0` 就是撤回）。时长写 `PUT /v2/me/playtimes/{id}` `{minutes}`，状态写 `PUT /v2/me/work-states/{id}`；写完再读一次折叠分钟回来，因为用户的其它应用可能报了更大的数，直接回显自己写的会和页面上的数字打架。`minutes = 0` 只写 playtime，不动 work-state。
 - 读：galgame 详情里的 `my_playtime`（和封面投票一样是逐请求带 token 的水合，不进缓存）；`GET /galgame/playtime/mine` 是个人页的列表。
-- `/mine` 是同步面不是浏览面：`updated_at` 升序 + 游标。论坛一次扫最多 5 页 × 200 条，本地折叠、按 `updated_at` 倒序、再分页；扫不完时 `truncated = true`。
+- `/mine` 是同步面不是浏览面：v2 按变更升序 + `cursor=`。论坛一次扫最多 10 页 × 100 条，本地折叠（MAX 分钟、按扫到的行数计 `clients`），再按每部作品在行流里最后一次出现的下标倒序（v2 行不再带时间戳，这是「最近改动优先」的代理），再分页；扫不完时 `truncated = true`。
+
+## 游玩状态（work-state）
+
+状态不在 playtime 行上。catalog 另有 `/v2/me/work-states/{id}`（列表 `/v2/me/work-states`），词表 `wish|doing|done|on_hold|dropped`，可选 `completion`（`one_route|main|all`）。论坛上报时长时两个资源一起写；写状态前先 GET 一次，若已有非空 `completion` 则原样带回 PUT——缺省该字段会清掉其它应用（如 bangumi 同步）写过的值。`wish` 只展示为「想玩」，记录弹窗没有这一项，遇到 wish 或空则预选 `doing`。公开中位数只计 `state = done` 的上报者。
 
 ## 第三方客户端
 
@@ -26,7 +30,7 @@
 
 - `PUT /v1/playtime/by-ref/{source}/{externalID}` 让客户端用手里的 vndb / dlsite id 直接上报，不必先查 work id。
 - `POST /v1/playtime/batch`（≤ 200）是首次登录的库存同步。
-- 逐条记录按 `(user, work, client_id)` 唯一，所以论坛和客户端是**并列**关系，不是覆盖关系。个人页把不是论坛写的那一条标成「其它应用」。
+- 逐条记录按 `(user, work, client_id)` 唯一，所以论坛和客户端是**并列**关系，不是覆盖关系。v2 个人列表不再带 `client_id`，论坛不再把某一行标成「其它应用」；`clients` 仍是扫到的每部作品的应用行数。
 - 聚合作业有 `--exclude-clients`：某一条上报通道被刷了，可以整条摘掉而不动别人的数据。这也是「先允许手填」的底气。
 
 ## 两条不要碰的线


### PR DESCRIPTION
Forum P0 of the work-state track — catalog's `/v2/me/work-states` (spec 2.20.0) is live, so the forum stops collecting a status it silently discards.

**What was broken (all verified against the live v2 face):**
- `ReportPlaytime` sent `{minutes}` only — the 游玩状态 radio did nothing.
- `v2Playtime` parsed `status`/`clients`/`client_id`/`last_played_at`/`updated_at` — v2 playtime rows carry **none** of them: empty status chips, every row marked 「来自其它应用」, 已通关 count stuck at 0, meaningless sort.
- The sweep sent `limit=200` (v2 caps at 100 → 400 `LIMIT_TOO_LARGE`, not clamped) and the continuation cursor as `updated_since=`, a parameter the v2 face does not have — `/galgame/playtime/mine` failed upstream.

**The wiring:**
- New `catalogclient` work-state methods (single GET 404→nil, PUT with omitted-nil completion, `work_ids=` batch); vocabulary `doing|done|on_hold|dropped` adopted end to end (labels unchanged; `wish` display-tolerated on reads, modal preselects 游玩中).
- Report writes **both** resources and **preserves upstream completion** (an absent completion on PUT clears it — a bangumi-sync app's value must survive a forum edit). Withdrawing minutes (=0) leaves the state alone: it is a (user, work) fact shared across apps.
- Sweep: 10 pages × 100 with `cursor=`; fold keeps MAX minutes + per-work row count; ordering by last-occurrence index (v2 rows carry no timestamp); mine list batch-joins work-states; `finished_works` = swept works with `state=done`.
- Removed rather than faked: `external`, `last_played_at`, `updated_at` off the mine item; `clients` off the single read. The 「已通关才计入中位数」 copy is true again — the aggregate now gates on `state=done`.

Gates: `go build/vet/test ./...` green; `vue-tsc`, `eslint`, vitest 147/147 green. No route changes; `routes.golden` untouched.

Out of scope, deliberately: the rating `play_status` vocabulary, a wish option or completion editing in the UI (product waves), OAuth scopes (work-states need none).

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD