### PR TITLE
fix(galgame): mint a new (non-VNDB) work with its full fields

### DIFF
--- a/apps/api/pkg/catalogclient/user_claims.go
+++ b/apps/api/pkg/catalogclient/user_claims.go
@@ -25,6 +25,12 @@ func (c *Client) SubmitWorkUser(ctx context.Context, accessToken string, req Use
 	if req.ProductWorkID > 0 {
 		body["site_work_id"] = strconv.FormatInt(req.ProductWorkID, 10)
 	}
+	if len(req.Fields) > 0 {
+		body["field_values"] = req.Fields
+	}
+	if req.Released != nil {
+		body["released"] = req.Released
+	}
 	var out v2Claim
 	if err := c.userV2JSON(ctx, http.MethodPost, accessToken, "/v2/me/claims", body, &out, nil); err != nil {
 		return nil, err


### PR DESCRIPTION
## Bug / 问题

Creating a brand-new work that is **not listed on VNDB** (VNDB 未收录) on the forum fails even when the form is fully filled out. The request is refused with catalog `422`:

```
work_id, refs, site_work_id, or field_values is required.
```

在论坛上创建 **VNDB 未收录**的全新作品时，即使表单已填完整，请求仍会被 catalog 以 422 拒绝。

## Root cause / 成因

`catalogclient.SubmitWorkUser` (used by the submission wizard's mint path) only forwarded `display_name` and an optional `site_work_id` to `POST /v2/me/claims`. It **dropped the full editing-engine field map (`req.Fields`) and the release date (`req.Released`)**.

Catalog's mint lane requires at least one of `work_id` / `refs` / `site_work_id` / `field_values`. A brand-new non-VNDB work has no upstream ref and no `site_work_id` yet (the local id does not exist until the mint returns), so the body degenerated to `display_name` alone — which is not a lane — and every mint was refused. This is independent of the token `iss`/environment issue and reproduces in production too.

`SubmitWorkUser`（投稿向导铸造新车道的入口）只把 `display_name` 和可选的 `site_work_id` 发给了 `POST /v2/me/claims`，**丢掉了完整的编辑引擎字段表 `req.Fields` 和发售日期 `req.Released`**。

catalog 的铸造车道要求 `work_id` / `refs` / `site_work_id` / `field_values` 至少存在其一。全新且不在 VNDB 上的作品既没有上游 ref，也没有 `site_work_id`（本地 id 要等铸造返回后才存在），于是请求体只剩 `display_name`——而它不算铸造车道——所以每次铸造都被拒绝。此问题与 token 的 `iss`/环境问题无关，生产环境同样会触发。

## Fix / 解决方式

Send the full map as `field_values` (and the date as `released`) on the claim body:

在请求体中携带完整的字段表 `field_values`（以及 `released`）：

```go
if len(req.Fields) > 0 {
    body["field_values"] = req.Fields
}
if req.Released != nil {
    body["released"] = req.Released
}
```

## Verification / 验证

- `go build ./pkg/catalogclient/` passes.
- The submitter manually verified in the local dev environment that creating a new non-VNDB work now mints successfully.
- `go build ./pkg/catalogclient/` 通过；
- 提交者已在本地 dev 环境手动验证：创建 VNDB 未收录的新作品可以正常铸造成功。
