### PR TITLE
fix(galgame): credit galgame-resource likes to the resource author

### DIFF
--- a/apps/api/internal/galgame/service/resource_service.go
+++ b/apps/api/internal/galgame/service/resource_service.go
@@ -503,7 +503,7 @@ func (s *ResourceService) ToggleLike(
 		if err := s.resourceRepo.AdjustLikeCount(tx, req.GalgameResourceID, delta); err != nil {
 			return err
 		}
-		s.helpers.AdjustMoemoepoint(tx, userID, delta,
+		s.helpers.AdjustMoemoepoint(tx, row.UserID, delta,
 			moemoepoint.ReasonLiked, moemoepoint.Ref("galgame_resource", req.GalgameResourceID))
 		return s.helpers.CreateGalgameMessageWithContent(
 			tx, userID, row.UserID, "liked", preview, row.GalgameID,

--- a/apps/web/app/components/kun/top-bar/MoemoepointLog.vue
+++ b/apps/web/app/components/kun/top-bar/MoemoepointLog.vue
@@ -24,7 +24,8 @@ const REASON_META: Record<string, { label: string; icon: string }> = {
   admin_grant: { label: '管理员发放', icon: 'lucide:gift' },
   admin_deduct: { label: '管理员扣除', icon: 'lucide:gavel' },
   migration: { label: '初始迁移', icon: 'lucide:database' },
-  register_gift: { label: '注册礼物', icon: 'lucide:party-popper' }
+  register_gift: { label: '注册礼物', icon: 'lucide:party-popper' },
+  name_change: { label: '修改用户名', icon: 'lucide:user-round-pen' }
 }
 
 const SOURCE_LABEL: Record<string, string> = {


### PR DESCRIPTION
## Bug / 问题

Liking (or unliking) a **galgame resource** gave moemoepoints to the **liker themselves** (+1 on like, −1 on unlike), while the "liked" notification went to the resource author. Every other like path in the product (topic / reply / comment / rating / galgame / quiz) credits the **content author**, so resource likes were the odd one out — effectively a self-rewarding, easily farmed point source.

给**游戏资源**点赞/取消点赞时，萌萌点加给了**点赞者本人**（点赞 +1、取消 −1），而"被赞"通知却发给资源作者。站内其它所有点赞路径（话题/回复/评论/评分/游戏/问答）都是加给**内容作者**，唯独资源点赞相反——等于给自己刷分，还和通知对象错位。

## Root cause / 成因

`ResourceService.ToggleLike` (`apps/api/internal/galgame/service/resource_service.go`) called:

```go
s.helpers.AdjustMoemoepoint(tx, userID, delta, ...)
```

`userID` here is the **actor (liker)**; the author is `row.UserID`. The moemoepoint target was simply the wrong variable.

`userID` 是**操作者（点赞人）**，资源作者是 `row.UserID`，这里把加分对象传成了点赞者。

## Fix / 解决方式

Credit the author instead:

```go
s.helpers.AdjustMoemoepoint(tx, row.UserID, delta, ...)
```

改为加给资源作者。

Also adds the `name_change` reason label (`修改用户名`) to the moemoepoint ledger modal so the upcoming OAuth rename-cost entry renders with a readable label.

顺带在萌萌点明细弹层里补了 `name_change`（修改用户名）的显示文案，供 OAuth 改名扣费功能使用。

## Verification / 验证

- `go build ./...` in `apps/api` passes.
- Behavior now matches every other like path: like → author +1, unlike → author −1 (the resource author, not the liker, is credited).

- `apps/api` 下 `go build ./...` 通过；
- 行为与其它点赞路径一致：点赞 → 作者 +1，取消 → 作者 −1。
