### PR TITLE
feat(web): add /point moemoepoint rules page and announce the rename cost

### DIFF
--- a/apps/web/app/components/kun/top-bar/MoemoepointLog.vue
+++ b/apps/web/app/components/kun/top-bar/MoemoepointLog.vue
@@ -242,6 +242,16 @@ watch(isOpen, (open) => {
           加载更多
         </KunButton>
       </div>
+
+      <div class="border-default-200 flex items-center justify-center border-t pt-2">
+        <KunLink
+          to="/point"
+          class="text-primary text-sm underline underline-offset-4"
+          @click="isOpen = false"
+        >
+          萌萌点收支细则
+        </KunLink>
+      </div>
     </div>
   </KunModal>
 </template>

--- a/apps/web/app/components/point/Container.vue
+++ b/apps/web/app/components/point/Container.vue
@@ -5,7 +5,7 @@
   <div class="space-y-6 pb-12">
     <KunHeader
       name="萌萌点说明"
-      description="萌萌点是整个鲲 Galgame 生态通用的社区积分。它不能买东西, 更像是对贡献的感谢: 你帮忙整理内容、认真写点评、热心回帖, 就会得到别人的谢谢(萌萌点); 用来鼓励分享和互动的几个动作, 则需要花一点萌萌点。"
+      description="萌萌点是整个鲲 Galgame 生态通用的社区积分。你帮忙整理内容、认真写点评、热心回帖, 就会得到别人的谢谢(萌萌点)。"
     />
 
     <KunCard class="space-y-3">
@@ -24,11 +24,11 @@
           作者 +1; 取消点赞会把这 1 点收回去(见下面小贴士)。
         </li>
         <li>
-          <b class="text-foreground">认真写评分 +3 / +5 / +10</b>: 游戏评分按"短评"长短给奖励——写够 233
+          <b class="text-foreground">认真写评分 +3 / +5 / +10</b>: 游戏评分按长短给奖励——写够 233
           字奖励 +5, 写够 666 字奖励 +10, 更短的也有 +3。
         </li>
         <li>
-          <b class="text-foreground">出题 +2</b>: 给游戏出一道理性问答题目, 出题人 +2。
+          <b class="text-foreground">出题 +2</b>: 给游戏出一道问答题目, 出题人 +2。
         </li>
         <li>
           <b class="text-foreground">被选为最佳回答 +7</b>: 你的回复被楼主设为"最佳回答", +7。
@@ -50,54 +50,38 @@
       <h2 class="text-foreground text-lg font-bold">什么时候会花掉萌萌点?</h2>
       <ul class="text-default-600 list-disc space-y-1.5 pl-5 text-sm">
         <li>
-          <b class="text-foreground">推话题 -10</b>: 想帮别人把话题顶起来, 每次要花 10 点(同时楼主收到
-          +5)。余额不足 10 点时不能推, 也不能推自己的话题。
+          <b class="text-foreground">推话题 -10</b>：想帮别人把话题顶起来，每次花 10
+          点（同时楼主收到 +5）。余额不足 10 点不能推，也不能推自己的话题。
         </li>
         <li>
-          <b class="text-foreground">发到"需要消耗"的板块 -10</b>: 这类板块发话题前会先扣 10 点,
-          而且这种帖子不再给你 +3 的发帖奖励。余额不足时不能发。
+          <b class="text-foreground">发到"需要消耗"的板块 -10</b>：这类板块发话题前会先扣 10
+          点，且不再给你 +3 的发帖奖励，余额不足不能发。
         </li>
         <li>
-          <b class="text-foreground">改名 -17</b>: 修改一次用户名花 17 点, 余额不足时改不了。
+          <b class="text-foreground">改名 -17</b>：修改一次用户名花 17 点，余额不足改不了。
         </li>
         <li>
-          <b class="text-foreground">删除内容会被"回扣"</b>: 站里不鼓励发完就删, 所以删除会按内容类型收回之前给过你的奖励,
-          删得越"热"的扣得越多——
+          <b class="text-foreground">删除内容会被"回扣"</b>：不鼓励发完就删，删除按内容类型收回之前的奖励——
           <ul class="text-default-600 mt-1 list-disc space-y-1 pl-5">
+            <li><b class="text-foreground">删评分</b>：退回当初奖励（3 / 5 / 10）；</li>
+            <li><b class="text-foreground">删问答题目</b>：-2（收回出题奖励）；</li>
             <li>
-              <b class="text-foreground">删评分</b>: 退回当初拿到的奖励(按原短评长度 3 / 5 / 10 点);
+              <b class="text-foreground">删自己的回复</b>：3 × (被评论数 + 被赞数 + 1)；
             </li>
-            <li>
-              <b class="text-foreground">删问答题目</b>: 收回出题奖励, -2;
-            </li>
-            <li>
-              <b class="text-foreground">删自己的回复</b>: 扣 <b class="text-foreground">3 × (被评论数 + 被赞数 +
-              1)</b>——这条回复收到的每条评论、每个赞, 当初都给过你 +1, 删掉时一并收回;
-            </li>
-            <li>
-              <b class="text-foreground">删自己的评论</b>: 扣 <b class="text-foreground">3 × (被赞数 +
-              1)</b>;
-            </li>
-            <li>
-              <b class="text-foreground">删一条游戏资源</b>: 扣 <b class="text-foreground">(被赞数 +
-              5)</b>;
-            </li>
-            <li>
-              <b class="text-foreground">删工具 / 删工具资源</b>: 各 -3。
-            </li>
+            <li><b class="text-foreground">删自己的评论</b>：3 × (被赞数 + 1)；</li>
+            <li><b class="text-foreground">删一条游戏资源</b>：(被赞数 + 5)；</li>
+            <li><b class="text-foreground">删工具 / 删工具资源</b>：各 -3；</li>
+            <li>（余额不够扣会提示"萌萌点不足"而不让删）</li>
           </ul>
-          删除时如果余额不够扣, 系统会提示"萌萌点不足"而不让删。
         </li>
         <li>
-          <b class="text-foreground">最佳回答被撤销 -7</b>: 你被设为"最佳回答"时 +7;
-          如果楼主之后取消了这条最佳回答, 会把这 7 点收回去。
+          <b class="text-foreground">最佳回答被撤销 -7</b>：被设最佳回答 +7，楼主撤销后收回这 7 点。
         </li>
         <li>
-          <b class="text-foreground">取消点赞 / 取消收藏</b>: 会把之前送给对方的那 1 点从对方那里收回来(对方
-          -1), 所以点下去之前想清楚, 别反复横跳。
+          <b class="text-foreground">取消点赞 / 取消收藏</b>：把之前送给对方的那 1 点收回（对方 -1）。
         </li>
         <li>
-          <b class="text-foreground">内容被平台处理</b>: 违规内容被移除时, 之前因此拿到的奖励可能一并收回, 以审核结果为准。
+          <b class="text-foreground">内容被平台处理</b>：违规被移除时，相关奖励可能一并收回，以审核为准。
         </li>
       </ul>
     </KunCard>
@@ -114,7 +98,8 @@
         </li>
         <li>被管理员处理的内容可能被扣回之前的奖励; 具体以审核结果为准。</li>
         <li>
-          规则会随版本更新, 本页只是把当前规则说清楚; 具体每一笔收支都能在右上角 <b class="text-foreground">萌萌点明细</b> 里看到。
+          规则会随版本更新, 本页只是把当前规则说清楚; 具体每一笔收支都能在右上角
+          <b class="text-foreground">萌萌点——萌萌点明细</b> 里看到。
         </li>
       </ul>
     </KunCard>

--- a/apps/web/app/components/point/Container.vue
+++ b/apps/web/app/components/point/Container.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div class="space-y-6 pb-12">
+    <KunHeader
+      name="萌萌点说明"
+      description="萌萌点是整个鲲 Galgame 生态通用的社区积分。它不能买东西, 更像是对贡献的感谢: 你帮忙整理内容、认真写点评、热心回帖, 就会得到别人的谢谢(萌萌点); 用来鼓励分享和互动的几个动作, 则需要花一点萌萌点。"
+    />
+
+    <KunCard class="space-y-3">
+      <h2 class="text-foreground text-lg font-bold">平时怎么赚萌萌点?</h2>
+      <ul class="text-default-600 list-disc space-y-1.5 pl-5 text-sm">
+        <li>
+          <b class="text-foreground">发内容 +3</b>: 发布一个话题、添加一条游戏资源、新建一个工具、给工具传一个资源,
+          都是 +3。游戏条目比较特殊——你的投稿在正式通过审核、被收录时, 会给你 +3。
+        </li>
+        <li>
+          <b class="text-foreground">别人回复你 +1</b>: 有人在你的话题下回帖, 你 +1;
+          有人在你某条回复下发评论, 你 +1。
+        </li>
+        <li>
+          <b class="text-foreground">被点赞/收藏 +1</b>: 话题、回复、评论、游戏、游戏资源、评分、问答……这些内容被别人点赞/收藏时,
+          作者 +1; 取消点赞会把这 1 点收回去(见下面小贴士)。
+        </li>
+        <li>
+          <b class="text-foreground">认真写评分 +3 / +5 / +10</b>: 游戏评分按"短评"长短给奖励——写够 233
+          字奖励 +5, 写够 666 字奖励 +10, 更短的也有 +3。
+        </li>
+        <li>
+          <b class="text-foreground">出题 +2</b>: 给游戏出一道理性问答题目, 出题人 +2。
+        </li>
+        <li>
+          <b class="text-foreground">被选为最佳回答 +7</b>: 你的回复被楼主设为"最佳回答", +7。
+        </li>
+        <li>
+          <b class="text-foreground">话题被推荐 +5</b>: 有人花萌萌点把你的话题顶上热榜, 楼主收到 +5。
+        </li>
+        <li>
+          <b class="text-foreground">编辑被采纳 +1</b>: 你对游戏条目提交的修改被合并, 提案人 +1。
+        </li>
+        <li>
+          <b class="text-foreground">每天签到</b>: 每天签到拿随机 0~7 点。
+        </li>
+        <li>部分站内活动(比如抽奖)也会发放萌萌点, 以活动说明为准。</li>
+      </ul>
+    </KunCard>
+
+    <KunCard class="space-y-3">
+      <h2 class="text-foreground text-lg font-bold">什么时候会花掉萌萌点?</h2>
+      <ul class="text-default-600 list-disc space-y-1.5 pl-5 text-sm">
+        <li>
+          <b class="text-foreground">推话题 -10</b>: 想把别人的话题顶起来, 需要花 10 点(对方得 5)。萌萌点不够时不能推。
+        </li>
+        <li>
+          <b class="text-foreground">发到"需要消耗"的板块 -10</b>: 这类板块发话题要先扣 10 点, 而且不会给你发帖奖励。
+        </li>
+        <li>
+          <b class="text-foreground">改名 -17</b>: 修改用户名要花 17 点。
+        </li>
+        <li>
+          <b class="text-foreground">删除内容会扣回</b>: 站里不鼓励"发完就删"。删得越"热"的内容扣得越多——删自己一条回复要扣
+          <b class="text-foreground">3 × (被评论数 + 被赞数 + 1)</b>, 删自己一条评论扣
+          <b class="text-foreground">3 × (被赞数 + 1)</b>。删评分会退回当初拿到的奖励(3/5/10),
+          删一条游戏资源会扣 <b class="text-foreground">(被赞数 + 5)</b>, 删工具 / 工具资源各 -3, 所以删之前想清楚。
+        </li>
+      </ul>
+    </KunCard>
+
+    <KunCard class="space-y-3">
+      <h2 class="text-foreground text-lg font-bold">几条小贴士</h2>
+      <ul class="text-default-600 list-disc space-y-1.5 pl-5 text-sm">
+        <li>
+          点赞是"把 1 点送给对方", 取消点赞会把那 1 点从对方那里拿回来——所以点下去之前想一下, 别反复横跳。
+        </li>
+        <li>
+          你当天能发的话题数跟余额挂钩: 大约 <b class="text-foreground">每 10 点萌萌点 + 1 篇</b>
+          上限(比如 100 点 = 一天最多 11 篇)。
+        </li>
+        <li>被管理员处理的内容可能被扣回之前的奖励; 具体以审核结果为准。</li>
+        <li>
+          规则会随版本更新, 本页只是把当前规则说清楚; 具体每一笔收支都能在右上角 <b class="text-foreground">萌萌点明细</b> 里看到。
+        </li>
+      </ul>
+    </KunCard>
+  </div>
+</template>

--- a/apps/web/app/components/point/Container.vue
+++ b/apps/web/app/components/point/Container.vue
@@ -50,19 +50,54 @@
       <h2 class="text-foreground text-lg font-bold">什么时候会花掉萌萌点?</h2>
       <ul class="text-default-600 list-disc space-y-1.5 pl-5 text-sm">
         <li>
-          <b class="text-foreground">推话题 -10</b>: 想把别人的话题顶起来, 需要花 10 点(对方得 5)。萌萌点不够时不能推。
+          <b class="text-foreground">推话题 -10</b>: 想帮别人把话题顶起来, 每次要花 10 点(同时楼主收到
+          +5)。余额不足 10 点时不能推, 也不能推自己的话题。
         </li>
         <li>
-          <b class="text-foreground">发到"需要消耗"的板块 -10</b>: 这类板块发话题要先扣 10 点, 而且不会给你发帖奖励。
+          <b class="text-foreground">发到"需要消耗"的板块 -10</b>: 这类板块发话题前会先扣 10 点,
+          而且这种帖子不再给你 +3 的发帖奖励。余额不足时不能发。
         </li>
         <li>
-          <b class="text-foreground">改名 -17</b>: 修改用户名要花 17 点。
+          <b class="text-foreground">改名 -17</b>: 修改一次用户名花 17 点, 余额不足时改不了。
         </li>
         <li>
-          <b class="text-foreground">删除内容会扣回</b>: 站里不鼓励"发完就删"。删得越"热"的内容扣得越多——删自己一条回复要扣
-          <b class="text-foreground">3 × (被评论数 + 被赞数 + 1)</b>, 删自己一条评论扣
-          <b class="text-foreground">3 × (被赞数 + 1)</b>。删评分会退回当初拿到的奖励(3/5/10),
-          删一条游戏资源会扣 <b class="text-foreground">(被赞数 + 5)</b>, 删工具 / 工具资源各 -3, 所以删之前想清楚。
+          <b class="text-foreground">删除内容会被"回扣"</b>: 站里不鼓励发完就删, 所以删除会按内容类型收回之前给过你的奖励,
+          删得越"热"的扣得越多——
+          <ul class="text-default-600 mt-1 list-disc space-y-1 pl-5">
+            <li>
+              <b class="text-foreground">删评分</b>: 退回当初拿到的奖励(按原短评长度 3 / 5 / 10 点);
+            </li>
+            <li>
+              <b class="text-foreground">删问答题目</b>: 收回出题奖励, -2;
+            </li>
+            <li>
+              <b class="text-foreground">删自己的回复</b>: 扣 <b class="text-foreground">3 × (被评论数 + 被赞数 +
+              1)</b>——这条回复收到的每条评论、每个赞, 当初都给过你 +1, 删掉时一并收回;
+            </li>
+            <li>
+              <b class="text-foreground">删自己的评论</b>: 扣 <b class="text-foreground">3 × (被赞数 +
+              1)</b>;
+            </li>
+            <li>
+              <b class="text-foreground">删一条游戏资源</b>: 扣 <b class="text-foreground">(被赞数 +
+              5)</b>;
+            </li>
+            <li>
+              <b class="text-foreground">删工具 / 删工具资源</b>: 各 -3。
+            </li>
+          </ul>
+          删除时如果余额不够扣, 系统会提示"萌萌点不足"而不让删。
+        </li>
+        <li>
+          <b class="text-foreground">最佳回答被撤销 -7</b>: 你被设为"最佳回答"时 +7;
+          如果楼主之后取消了这条最佳回答, 会把这 7 点收回去。
+        </li>
+        <li>
+          <b class="text-foreground">取消点赞 / 取消收藏</b>: 会把之前送给对方的那 1 点从对方那里收回来(对方
+          -1), 所以点下去之前想清楚, 别反复横跳。
+        </li>
+        <li>
+          <b class="text-foreground">内容被平台处理</b>: 违规内容被移除时, 之前因此拿到的奖励可能一并收回, 以审核结果为准。
         </li>
       </ul>
     </KunCard>

--- a/apps/web/app/components/user/setting/Username.vue
+++ b/apps/web/app/components/user/setting/Username.vue
@@ -32,7 +32,8 @@ const handleChangeUsername = async () => {
     <div>
       <span class="text-xl">更改用户名</span>
       <p class="text-default-500 text-sm">
-        用户名为 1~17 位任意字符, 全局唯一。当前: {{ userStore.name }}
+        用户名为 1~17 位任意字符, 全局唯一。改名需要 17 个萌萌点。当前:
+        {{ userStore.name }}
       </p>
     </div>
 

--- a/apps/web/app/pages/point/index.vue
+++ b/apps/web/app/pages/point/index.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+definePageMeta({
+  pageTransition: { name: 'kun-page', mode: 'out-in' }
+})
+
+useKunSeoMeta({
+  title: '萌萌点说明',
+  description:
+    '萌萌点是什么、平时怎么赚、又会在哪里花掉——用大白话讲清楚本站的萌萌点收支规则。'
+})
+</script>
+
+<template>
+  <div class="min-w-0">
+    <PointContainer />
+  </div>
+</template>


### PR DESCRIPTION
## What / 内容

A plain-language page explaining the current moemoepoint income/expense rules, reachable from the moemoepoint ledger.

一个用大白话介绍当前萌萌点收支细则的页面，并把它接到萌萌点明细入口。

- **New page `/point`** (`pages/point` + `components/point`): explains in everyday language how moemoepoints are earned (posting, being liked/replied, rating length tiers, best answer, upvote, check-in, …) and spent (upvoting −10, paid sections −10, **rename −17**, deletion claw-backs, …).
- **Ledger entry**: the moemoepoint detail modal (avatar → 萌萌点 → 明细) now has a blue underlined "萌萌点收支细则" link at the bottom pointing to `/point`.
- **Rename hint**: the "更改用户名" setting now states the cost up front ("改名需要 17 个萌萌点。"), matching the OAuth rename-charge feature.

- 新增页面 `/point`：用大白话列出萌萌点的收入（发内容、被赞/被回复、评分字数档位、最佳回答、话题被推荐、签到等）与支出（推话题 −10、扣分板块 −10、**改名 −17**、删除回扣等）。
- 入口：萌萌点明细弹层（头像 → 萌萌点 → 明细）底部新增蓝色下划线链接「萌萌点收支细则」，指向 `/point`。
- 提示语：用户设置里的「更改用户名」现在会提前写明成本（"改名需要 17 个萌萌点。"），与 OAuth 改名扣费功能一致。

## Why / 原因

Users had no single, human-readable place to learn what earns or costs moemoepoints, and the rename UI did not surface that a rename now costs 17 points (the OAuth-side charge was introduced in the companion infra PR).

用户没有一个能看懂"什么动作赚/扣萌萌点"的集中说明，改名界面也没有提前告知改名需要 17 点（OAuth 侧扣费由配套 infra PR 引入）。

## Verification / 验证

- Nuxt dev hot-reloads; `/point` renders with the shared page layout and the ledger-modal footer link and rename hint appear as expected.

- Nuxt dev 可热更新；`/point` 使用站点统一布局渲染，明细弹层底部链接与改名提示语均按预期显示。
